### PR TITLE
Fix: Test context leakage on test failure

### DIFF
--- a/src/TestLifecycle.php
+++ b/src/TestLifecycle.php
@@ -15,17 +15,20 @@ class TestLifecycle
 {
     public static function evaluate(): void
     {
-        $evaluations = TestContext::getCurrentEvaluations();
+        try {
+            $evaluations = TestContext::getCurrentEvaluations();
 
-        foreach ($evaluations as $evaluation) {
-            if (empty($evaluation->testCases())) {
-                continue;
+            foreach ($evaluations as $evaluation) {
+                if (empty($evaluation->testCases())) {
+                    continue;
+                }
+
+                self::handleEvaluationResult(Promptfoo::evaluate($evaluation));
             }
-
-            self::handleEvaluationResult(Promptfoo::evaluate($evaluation));
+        } finally {
+            // Always clear evaluations, even if an exception was thrown
+            TestContext::clear();
         }
-
-        TestContext::clear();
     }
 
     private static function handleEvaluationResult(EvaluationResult $evaluationResult): void


### PR DESCRIPTION
## Fix: Test context leakage on test failure

### Problem
When a test fails, evaluations remain in `TestContext` and leak to the next test, causing subsequent tests to fail incorrectly.

### Solution
Added `try-finally` block to `TestLifecycle::evaluate()` to ensure `TestContext::clear()` is always called, even when an exception is thrown during evaluation.

### Changes
- Wrapped evaluation logic in `try-finally` block
- Moved `TestContext::clear()` to `finally` block to guarantee cleanup

Fixes test isolation issue where failed tests affect subsequent tests.