### PR TITLE
Add support to allow assertions on structured output

### DIFF
--- a/src/Internal/Results/Response.php
+++ b/src/Internal/Results/Response.php
@@ -9,17 +9,24 @@ namespace KevinPijning\Prompt\Internal\Results;
  */
 final readonly class Response
 {
+    public string $output;
+
     /**
+     * @param  string|array<string, mixed>  $output
      * @param  array<string, mixed>  $tokenUsage
      * @param  array<string, mixed>  $guardrails
      */
     public function __construct(
-        public string $output,
+        string|array $output,
         public array $tokenUsage,
         public bool $cached,
         public int $latencyMs,
         public string $finishReason,
         public float $cost,
         public array $guardrails,
-    ) {}
+    ) {
+        $this->output = is_array($output)
+            ? json_encode($output, JSON_THROW_ON_ERROR)
+            : $output;
+    }
 }

--- a/tests/Internal/Results/ResponseTest.php
+++ b/tests/Internal/Results/ResponseTest.php
@@ -43,3 +43,33 @@ test('Response can be instantiated with empty arrays', function () {
         ->and($response->guardrails)->toBeArray()
         ->and($response->guardrails)->toBeEmpty();
 });
+
+test('Response transforms array output to JSON string', function () {
+    $response = new Response(
+        output: ['message' => 'Hello', 'code' => 200],
+        tokenUsage: [],
+        cached: false,
+        latencyMs: 100,
+        finishReason: 'stop',
+        cost: 0.0,
+        guardrails: [],
+    );
+
+    expect($response->output)->toBeString()
+        ->and($response->output)->toBe('{"message":"Hello","code":200}');
+});
+
+test('Response keeps string output as string', function () {
+    $response = new Response(
+        output: 'Simple text output',
+        tokenUsage: [],
+        cached: false,
+        latencyMs: 100,
+        finishReason: 'stop',
+        cost: 0.0,
+        guardrails: [],
+    );
+
+    expect($response->output)->toBeString()
+        ->and($response->output)->toBe('Simple text output');
+});


### PR DESCRIPTION
Add support for structured output, so assertions can be made.

Test to reproduce the issue:
```
<?php

declare(strict_types=1);

use KevinPijning\Prompt\Api\Provider;

/**
 * Simple test to demonstrate structured output support for OpenAI Responses API
 * 
 * This test will FAIL without the fix because:
 * - OpenAI Responses API with response_format returns an array
 * - Response class expects a string
 * - TypeError: Response::__construct(): Argument #1 ($output) must be of type string, array given
 */

 $provider = provider('structured-output-test', static fn (Provider $provider): Provider => $provider
    ->id('openai:responses:gpt-4o-mini')
    ->config([
        'response_format' => [
            'name' => 'person_info',
            'type' => 'json_schema',
            'strict' => true,
            'schema' => [
                'type' => 'object',
                'properties' => [
                    'name' => ['type' => 'string'],
                    'age' => ['type' => 'number'],
                    'city' => ['type' => 'string'],
                ],
                'required' => ['name', 'age', 'city'],
                'additionalProperties' => false,
            ],
        ],
    ]));

test('extracts person info as structured JSON', function () {
    $evaluation = prompt('Extract the person\'s name, age and city from this text.')
        ->describe('Testing structured output from OpenAI Responses API')
        ->usingProvider('structured-output-test');

    // because the output will be an array instead of a JSON string
    $evaluation->expect(['text' => 'John Doe is 30 years old and lives in Amsterdam.'])
        ->toContain('"name"')
        ->toContain('"age"')
        ->toContain('"city"');
});