### PR TITLE
feat: add source location tracking and simplify assertion group

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ prompt('Greet {{name}} warmly.')
 
 #### `to()` and `group()`
 
-Group multiple assertions together using a callback or invokable class. Both `to()` and `group()` are aliases that execute a callback with the current test case, allowing you to organize assertions logically.
+Group multiple assertions together using a callback or named assertion group. Both `to()` and `group()` are aliases that execute a callback with the current test case, allowing you to organize assertions logically.
 
 **Using callbacks:**
 
@@ -453,46 +453,34 @@ prompt('Review {{document}}.')
     ->to(fn (TestCase $tc) => $tc->toHaveLatency(1500));
 ```
 
-**Using invokable classes:**
+**Using named assertion groups:**
 
-You can also pass an invokable class (a class with an `__invoke()` method) to reuse assertion logic across multiple tests.
+You can also reference named assertion groups registered via `assertion()`:
 
 ```php
-// Define an invokable class
-class QualityAssertions
-{
-    public function __invoke(TestCase $testCase): void
-    {
-        $testCase
-            ->toBeJudged('response is professional and accurate')
-            ->toHaveLatency(2000)
-            ->not->toBeRefused();
-    }
-}
+// Register a reusable assertion group
+assertion('be professional')
+    ->toBeJudged('response is professional and accurate')
+    ->toHaveLatency(2000)
+    ->not->toBeRefused();
 
-// Use the class by FQN
+// Use by name
 prompt('Explain {{topic}}.')
     ->usingProvider('openai:gpt-4o-mini')
     ->expect(['topic' => 'AI'])
-    ->to(QualityAssertions::class);
-
-// Or use an instance
-prompt('Explain {{topic}}.')
-    ->usingProvider('openai:gpt-4o-mini')
-    ->expect(['topic' => 'AI'])
-    ->to(new QualityAssertions);
+    ->to('be professional');
 
 // Works with group() too
 prompt('Analyze {{data}}.')
     ->usingProvider('openai:gpt-4o-mini')
     ->expect(['data' => 'metrics'])
-    ->group(QualityAssertions::class);
+    ->group('be professional');
 ```
 
 **Key points:**
 - `to()` and `group()` are functionally identical - use whichever reads better in your context
-- Accepts either a callable or an invokable class FQN (fully qualified name)
-- The callback/invokable receives the current `TestCase` instance
+- Accepts a callable (closure or invokable instance) or a named assertion group string
+- The callback receives the current `TestCase` instance
 - Useful for organizing related assertions together
 - Can be chained multiple times
 - Works with all assertion methods
@@ -500,7 +488,7 @@ prompt('Analyze {{data}}.')
 **Use cases:**
 - Group related assertions for better code organization
 - Apply conditional logic based on test case variables
-- Reuse assertion patterns across multiple test cases with invokable classes
+- Reuse assertion patterns via named assertion groups
 - Create reusable assertion libraries for common quality checks
 
 ### Assertion Methods

--- a/src/Assertion.php
+++ b/src/Assertion.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace KevinPijning\Prompt;
 
-/**
- * Represents a promptfoo assertion configuration.
- *
- * @see https://www.promptfoo.dev/docs/configuration/expected-outputs/#assertion-properties
- */
 class Assertion
 {
     /**

--- a/src/Assertion.php
+++ b/src/Assertion.php
@@ -4,8 +4,23 @@ declare(strict_types=1);
 
 namespace KevinPijning\Prompt;
 
+/**
+ * Represents a promptfoo assertion configuration.
+ *
+ * @see https://www.promptfoo.dev/docs/configuration/expected-outputs/#assertion-properties
+ */
 class Assertion
 {
+    /**
+     * Internal config key namespace for pest-plugin-prompt metadata.
+     */
+    public const string INTERNAL_CONFIG_KEY = '__pest_plugin_prompt';
+
+    /**
+     * Key for the unique assertion ID within the internal config namespace.
+     */
+    public const string INTERNAL_ASSERTION_ID_KEY = 'assertion_id';
+
     /**
      * @param  string  $type  Type of assertion
      * @param  mixed  $value  The expected value, if applicable
@@ -53,5 +68,40 @@ class Assertion
         }
 
         return $prefix.$type;
+    }
+
+    /**
+     * Create a new Assertion with an internal assertion ID embedded in config.
+     *
+     * @param  string  $file  The source file path
+     * @param  int  $line  The source line number
+     * @param  int  $index  The assertion index within the test case
+     */
+    public function withInternalId(string $file, int $line, int $index): self
+    {
+        $assertionId = sha1(sprintf('%s:%d:%d', $file, $line, $index));
+
+        return new self(
+            type: $this->type,
+            value: $this->value,
+            threshold: $this->threshold,
+            weight: $this->weight,
+            provider: $this->provider,
+            rubricPrompt: $this->rubricPrompt,
+            config: array_merge(
+                $this->config ?? [],
+                [self::INTERNAL_CONFIG_KEY => [self::INTERNAL_ASSERTION_ID_KEY => $assertionId]],
+            ),
+            transform: $this->transform,
+            metric: $this->metric,
+        );
+    }
+
+    /**
+     * Get the internal assertion ID if present.
+     */
+    public function getInternalId(): ?string
+    {
+        return $this->config[self::INTERNAL_CONFIG_KEY][self::INTERNAL_ASSERTION_ID_KEY] ?? null;
     }
 }

--- a/src/Concerns/CanEnclose.php
+++ b/src/Concerns/CanEnclose.php
@@ -10,39 +10,28 @@ use KevinPijning\Prompt\Internal\AssertionGroupRegistry;
 trait CanEnclose
 {
     /**
-     * @param  callable(self): void|class-string|string  $expect
+     * @param  callable(self): void|string  $expect
      * @param  array<int|string,mixed>  $args  Arguments for named assertion groups only; ignored for callables
      */
     public function to(callable|string $expect, array $args = []): self
     {
         if (is_string($expect)) {
-            // First, try to resolve as a named assertion group
-            if (AssertionGroupRegistry::has($expect)) {
-                AssertionGroupRegistry::get($expect)->apply($this, $args);
-
-                return $this;
+            if (! AssertionGroupRegistry::has($expect)) {
+                throw new InvalidArgumentException("Assertion group '{$expect}' not found. Register it using assertion().");
             }
 
-            // Fallback to existing invokable class FQN behavior
-            if (! class_exists($expect)) {
-                throw new InvalidArgumentException("Class {$expect} does not exist.");
-            }
+            AssertionGroupRegistry::get($expect)->apply($this, $args);
 
-            if (! method_exists($expect, '__invoke')) {
-                throw new InvalidArgumentException("Class {$expect} must be callable or an invokable class.");
-            }
-
-            $expect = new $expect;
+            return $this;
         }
 
-        // For non-string callables, preserve existing behavior and ignore $args
         $expect($this);
 
         return $this;
     }
 
     /**
-     * @param  callable(self): void|class-string|string  $expectations
+     * @param  callable(self): void|string  $expectations
      * @param  array<int|string,mixed>  $args  Arguments for named assertion groups only; ignored for callables
      */
     public function group(callable|string $expectations, array $args = []): self

--- a/src/Exceptions/PromptAssertionFailedException.php
+++ b/src/Exceptions/PromptAssertionFailedException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinPijning\Prompt\Exceptions;
+
+use KevinPijning\Prompt\Helpers\SourceLocation;
+use NunoMaduro\Collision\Contracts\RenderableOnCollisionEditor;
+use PHPUnit\Framework\AssertionFailedError;
+use Whoops\Exception\Frame;
+
+final class PromptAssertionFailedException extends AssertionFailedError implements RenderableOnCollisionEditor
+{
+    public function __construct(
+        private readonly SourceLocation $sourceLocation,
+        string $message,
+    ) {
+        parent::__construct($message);
+    }
+
+    public function toCollisionEditor(): Frame
+    {
+        return new Frame([
+            'file' => $this->sourceLocation->file,
+            'line' => $this->sourceLocation->line,
+        ]);
+    }
+
+    public function getSourceLocation(): SourceLocation
+    {
+        return $this->sourceLocation;
+    }
+}

--- a/src/Helpers/SourceLocation.php
+++ b/src/Helpers/SourceLocation.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinPijning\Prompt\Helpers;
+
+final readonly class SourceLocation
+{
+    public function __construct(
+        public string $file,
+        public int $line,
+    ) {}
+
+    public static function capture(): ?self
+    {
+        return self::fromBacktrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
+    }
+
+    /**
+     * @param  array<int, array{file?: string, line?: int, ...}>  $backtrace
+     */
+    public static function fromBacktrace(array $backtrace): ?self
+    {
+        foreach ($backtrace as $frame) {
+            if (! isset($frame['file'], $frame['line'])) {
+                continue;
+            }
+
+            if (self::isPluginSourceFrame($frame['file'])) {
+                continue;
+            }
+
+            if (str_contains($frame['file'], DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+
+            return new self($frame['file'], $frame['line']);
+        }
+
+        return null;
+    }
+
+    private static function isPluginSourceFrame(string $file): bool
+    {
+        return str_contains($file, 'pest-plugin-prompt'.DIRECTORY_SEPARATOR.'src'.DIRECTORY_SEPARATOR);
+    }
+
+    public function isValid(): bool
+    {
+        return $this->file !== '' && $this->line > 0;
+    }
+}

--- a/src/Internal/BuiltTestCase.php
+++ b/src/Internal/BuiltTestCase.php
@@ -6,6 +6,9 @@ namespace KevinPijning\Prompt\Internal;
 
 use KevinPijning\Prompt\Assertion;
 
+/**
+ * @internal
+ */
 final readonly class BuiltTestCase
 {
     /**

--- a/src/Internal/BuiltTestCase.php
+++ b/src/Internal/BuiltTestCase.php
@@ -6,17 +6,25 @@ namespace KevinPijning\Prompt\Internal;
 
 use KevinPijning\Prompt\Assertion;
 
-/**
- * @internal
- */
 final readonly class BuiltTestCase
 {
     /**
      * @param  array<string,mixed>  $variables
-     * @param  Assertion[]  $assertions
+     * @param  TrackedAssertion[]  $trackedAssertions
      */
     public function __construct(
         public array $variables,
-        public array $assertions,
+        public array $trackedAssertions,
     ) {}
+
+    /**
+     * @return Assertion[]
+     */
+    public function assertions(): array
+    {
+        return array_map(
+            static fn (TrackedAssertion $tracked): Assertion => $tracked->assertion,
+            $this->trackedAssertions,
+        );
+    }
 }

--- a/src/Internal/TestLifecycle.php
+++ b/src/Internal/TestLifecycle.php
@@ -6,16 +6,22 @@ namespace KevinPijning\Prompt\Internal;
 
 use InvalidArgumentException;
 use KevinPijning\Prompt\Assertion;
+use KevinPijning\Prompt\Exceptions\PromptAssertionFailedException;
+use KevinPijning\Prompt\Helpers\SourceLocation;
 use KevinPijning\Prompt\Internal\Results\ComponentResult;
 use KevinPijning\Prompt\Internal\Results\GradingResult;
 use KevinPijning\Prompt\Internal\Results\Result;
 use KevinPijning\Prompt\Promptfoo\Promptfoo;
+use PHPUnit\Framework\Assert;
 
 /**
  * @internal
  */
 class TestLifecycle
 {
+    /** @var TrackedAssertion[] */
+    private static array $currentTrackedAssertions = [];
+
     public static function evaluate(): void
     {
         try {
@@ -28,12 +34,30 @@ class TestLifecycle
                     continue;
                 }
 
+                self::$currentTrackedAssertions = self::collectTrackedAssertions($built);
+
                 self::handleEvaluationResult(Promptfoo::evaluate($evaluation));
             }
         } finally {
-            // Always clear evaluations, even if an exception was thrown
             EvaluationRegistry::clear();
+            self::$currentTrackedAssertions = [];
         }
+    }
+
+    /**
+     * @return TrackedAssertion[]
+     */
+    private static function collectTrackedAssertions(BuiltEvaluation $built): array
+    {
+        $tracked = [];
+
+        foreach ($built->testCases as $testCase) {
+            foreach ($testCase->trackedAssertions as $trackedAssertion) {
+                $tracked[] = $trackedAssertion;
+            }
+        }
+
+        return $tracked;
     }
 
     private static function handleEvaluationResult(EvaluationResult $evaluationResult): void
@@ -60,9 +84,31 @@ class TestLifecycle
 
     private static function assertComponentResult(ComponentResult $componentResult, Result $result): void
     {
-        $message = self::buildFailureMessage($componentResult, $result);
+        self::countAssertion();
 
-        expect($componentResult->pass)->toBeTrue($message);
+        if ($componentResult->pass) {
+            return;
+        }
+
+        $message = self::buildFailureMessage($componentResult, $result);
+        $sourceLocation = self::findSourceLocation($componentResult->assertion);
+
+        throw new PromptAssertionFailedException($sourceLocation, $message);
+    }
+
+    private static function findSourceLocation(?Assertion $returnedAssertion): SourceLocation
+    {
+        if ($returnedAssertion instanceof Assertion) {
+            foreach (self::$currentTrackedAssertions as $tracked) {
+                if ($tracked->assertion->type === $returnedAssertion->type
+                    && $tracked->assertion->value === $returnedAssertion->value
+                    && $tracked->sourceLocation instanceof SourceLocation) {
+                    return $tracked->sourceLocation;
+                }
+            }
+        }
+
+        return new SourceLocation(__FILE__, __LINE__);
     }
 
     private static function buildFailureMessage(ComponentResult $componentResult, Result $result): string
@@ -106,5 +152,13 @@ class TestLifecycle
         }
 
         return $output;
+    }
+
+    /**
+     * Increment PHPUnit's assertion counter to properly track evaluated assertions.
+     */
+    private static function countAssertion(): void
+    {
+        Assert::assertCount(0, []);
     }
 }

--- a/src/Internal/TestLifecycle.php
+++ b/src/Internal/TestLifecycle.php
@@ -51,6 +51,14 @@ class TestLifecycle
     {
         $tracked = [];
 
+        // Include default test case assertions (from alwaysExpect())
+        if ($built->defaultTestCase instanceof BuiltTestCase) {
+            foreach ($built->defaultTestCase->trackedAssertions as $trackedAssertion) {
+                $tracked[] = $trackedAssertion;
+            }
+        }
+
+        // Include assertions from all test cases
         foreach ($built->testCases as $testCase) {
             foreach ($testCase->trackedAssertions as $trackedAssertion) {
                 $tracked[] = $trackedAssertion;
@@ -98,16 +106,30 @@ class TestLifecycle
 
     private static function findSourceLocation(?Assertion $returnedAssertion): SourceLocation
     {
-        if ($returnedAssertion instanceof Assertion) {
+        if (! $returnedAssertion instanceof Assertion) {
+            return new SourceLocation(__FILE__, __LINE__);
+        }
+
+        // 1. Prefer ID-based matching (unambiguous)
+        $returnedId = $returnedAssertion->getInternalId();
+
+        if ($returnedId !== null) {
             foreach (self::$currentTrackedAssertions as $tracked) {
-                if ($tracked->assertion->type === $returnedAssertion->type
-                    && $tracked->assertion->value === $returnedAssertion->value
-                    && $tracked->sourceLocation instanceof SourceLocation) {
+                $trackedId = $tracked->assertion->getInternalId();
+                if ($trackedId === $returnedId && $tracked->sourceLocation instanceof SourceLocation) {
                     return $tracked->sourceLocation;
                 }
             }
         }
 
+        // 2. Fallback: type + value match (for older outputs / edge cases)
+        foreach (self::$currentTrackedAssertions as $tracked) {
+            if ($tracked->matches($returnedAssertion) && $tracked->sourceLocation instanceof SourceLocation) {
+                return $tracked->sourceLocation;
+            }
+        }
+
+        // 3. Unknown source
         return new SourceLocation(__FILE__, __LINE__);
     }
 

--- a/src/Internal/TrackedAssertion.php
+++ b/src/Internal/TrackedAssertion.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KevinPijning\Prompt\Internal;
+
+use KevinPijning\Prompt\Assertion;
+use KevinPijning\Prompt\Helpers\SourceLocation;
+
+final readonly class TrackedAssertion
+{
+    public function __construct(
+        public Assertion $assertion,
+        public ?SourceLocation $sourceLocation = null,
+    ) {}
+
+    public function matches(Assertion $other): bool
+    {
+        return $this->assertion->type === $other->type
+            && $this->assertion->value === $other->value;
+    }
+}

--- a/src/Promptfoo/ConfigBuilder.php
+++ b/src/Promptfoo/ConfigBuilder.php
@@ -68,7 +68,7 @@ final readonly class ConfigBuilder
 
         return array_map(static fn (BuiltTestCase $testCase): array => array_filter([
             'vars' => $testCase->variables,
-            'assert' => $self->mapAssertions($testCase->assertions),
+            'assert' => $self->mapAssertions($testCase->assertions()),
         ]), $this->evaluation->testCases);
     }
 
@@ -85,7 +85,7 @@ final readonly class ConfigBuilder
 
         return array_filter([
             'vars' => $defaultTestCase->variables,
-            'assert' => $this->mapAssertions($defaultTestCase->assertions),
+            'assert' => $this->mapAssertions($defaultTestCase->assertions()),
         ]);
     }
 

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -44,9 +44,17 @@ class TestCase
 
         $this->shouldNegateNextAssertion = false;
 
+        $sourceLocation = SourceLocation::capture();
+        $assertionIndex = count($this->trackedAssertions);
+
+        // Attach internal ID for unambiguous source location mapping
+        $assertionWithId = $sourceLocation instanceof SourceLocation
+            ? $finalAssertion->withInternalId($sourceLocation->file, $sourceLocation->line, $assertionIndex)
+            : $finalAssertion;
+
         $this->trackedAssertions[] = new TrackedAssertion(
-            assertion: $finalAssertion,
-            sourceLocation: SourceLocation::capture(),
+            assertion: $assertionWithId,
+            sourceLocation: $sourceLocation,
         );
 
         return $this;

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -9,8 +9,10 @@ use InvalidArgumentException;
 use KevinPijning\Prompt\Concerns\CanEnclose;
 use KevinPijning\Prompt\Concerns\CanUseAssertions;
 use KevinPijning\Prompt\Helpers\AssertionGroupName;
+use KevinPijning\Prompt\Helpers\SourceLocation;
 use KevinPijning\Prompt\Internal\AssertionGroupRegistry;
 use KevinPijning\Prompt\Internal\BuiltTestCase;
+use KevinPijning\Prompt\Internal\TrackedAssertion;
 use RuntimeException;
 
 /**
@@ -21,8 +23,8 @@ class TestCase
     use CanEnclose;
     use CanUseAssertions;
 
-    /** @var Assertion[] */
-    private array $assertions = [];
+    /** @var TrackedAssertion[] */
+    private array $trackedAssertions = [];
 
     private bool $shouldNegateNextAssertion = false;
 
@@ -36,14 +38,16 @@ class TestCase
 
     public function assert(Assertion $assertion): self
     {
-        if (! $this->shouldNegateNextAssertion) {
-            $this->assertions[] = $assertion;
-
-            return $this;
-        }
+        $finalAssertion = $this->shouldNegateNextAssertion
+            ? $assertion->negate()
+            : $assertion;
 
         $this->shouldNegateNextAssertion = false;
-        $this->assertions[] = $assertion->negate();
+
+        $this->trackedAssertions[] = new TrackedAssertion(
+            assertion: $finalAssertion,
+            sourceLocation: SourceLocation::capture(),
+        );
 
         return $this;
     }
@@ -117,7 +121,7 @@ class TestCase
     {
         return new BuiltTestCase(
             variables: $this->variables,
-            assertions: $this->assertions,
+            trackedAssertions: $this->trackedAssertions,
         );
     }
 }

--- a/tests/AssertionGroupTest.php
+++ b/tests/AssertionGroupTest.php
@@ -40,11 +40,11 @@ test('assertion group applies fluent assertions to test case', function () {
 
     $group->apply($testCase);
 
-    expect($testCase->build()->assertions)->toHaveCount(2)
-        ->and($testCase->build()->assertions[0]->type)->toBe('icontains')
-        ->and($testCase->build()->assertions[0]->value)->toBe('hello')
-        ->and($testCase->build()->assertions[1]->type)->toBe('icontains')
-        ->and($testCase->build()->assertions[1]->value)->toBe('world');
+    expect($testCase->build()->assertions())->toHaveCount(2)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('icontains')
+        ->and($testCase->build()->assertions()[0]->value)->toBe('hello')
+        ->and($testCase->build()->assertions()[1]->type)->toBe('icontains')
+        ->and($testCase->build()->assertions()[1]->value)->toBe('world');
 });
 
 test('assertion group applies callback to test case', function () {
@@ -58,11 +58,11 @@ test('assertion group applies callback to test case', function () {
 
     $group->apply($testCase);
 
-    expect($testCase->build()->assertions)->toHaveCount(2)
-        ->and($testCase->build()->assertions[0]->type)->toBe('icontains')
-        ->and($testCase->build()->assertions[0]->value)->toBe('hello')
-        ->and($testCase->build()->assertions[1]->type)->toBe('llm-rubric')
-        ->and($testCase->build()->assertions[1]->value)->toBe('friendly');
+    expect($testCase->build()->assertions())->toHaveCount(2)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('icontains')
+        ->and($testCase->build()->assertions()[0]->value)->toBe('hello')
+        ->and($testCase->build()->assertions()[1]->type)->toBe('llm-rubric')
+        ->and($testCase->build()->assertions()[1]->value)->toBe('friendly');
 });
 
 test('assertion group callback receives test case as first parameter', function () {
@@ -89,8 +89,8 @@ test('assertion group with callback and extra parameters', function () {
 
     $group->apply($testCase, ['word' => 'hello']);
 
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->value)->toBe('hello');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->value)->toBe('hello');
 });
 
 test('assertion group throws exception for missing required parameter', function () {
@@ -126,9 +126,9 @@ test('assertion group supports positional arguments', function () {
 
     $group->apply($testCase, ['hello', 'world']);
 
-    expect($testCase->build()->assertions)->toHaveCount(2)
-        ->and($testCase->build()->assertions[0]->value)->toBe('hello')
-        ->and($testCase->build()->assertions[1]->value)->toBe('world');
+    expect($testCase->build()->assertions())->toHaveCount(2)
+        ->and($testCase->build()->assertions()[0]->value)->toBe('hello')
+        ->and($testCase->build()->assertions()[1]->value)->toBe('world');
 });
 
 test('assertion group supports optional parameters with defaults', function () {
@@ -141,8 +141,8 @@ test('assertion group supports optional parameters with defaults', function () {
 
     $group->apply($testCase, []);
 
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->value)->toBe('default');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->value)->toBe('default');
 });
 
 test('assertion group supports nullable parameters', function () {
@@ -157,7 +157,7 @@ test('assertion group supports nullable parameters', function () {
 
     $group->apply($testCase, []);
 
-    expect($testCase->build()->assertions)->toHaveCount(0);
+    expect($testCase->build()->assertions())->toHaveCount(0);
 });
 
 test('assertion group callback can receive assertion group instance as first parameter', function () {
@@ -173,11 +173,11 @@ test('assertion group callback can receive assertion group instance as first par
 
     $built = $testCase->build();
 
-    expect($built->assertions)->toHaveCount(2)
-        ->and($built->assertions[0]->type)->toBe('icontains')
-        ->and($built->assertions[0]->value)->toBe('hello')
-        ->and($built->assertions[1]->type)->toBe('llm-rubric')
-        ->and($built->assertions[1]->value)->toBe('friendly');
+    expect($built->assertions())->toHaveCount(2)
+        ->and($built->assertions()[0]->type)->toBe('icontains')
+        ->and($built->assertions()[0]->value)->toBe('hello')
+        ->and($built->assertions()[1]->type)->toBe('llm-rubric')
+        ->and($built->assertions()[1]->value)->toBe('friendly');
 });
 
 test('assertion group can use multiple assertion traits', function () {

--- a/tests/Concerns/CanBeClassifiedTest.php
+++ b/tests/Concerns/CanBeClassifiedTest.php
@@ -13,9 +13,9 @@ test('toBeClassified creates a classifier assertion', function () {
     $result = $testCase->toBeClassified('huggingface:model', 'positive', threshold: 0.8);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('classifier')
         ->and($assertion->value)->toBe('positive')
@@ -29,7 +29,7 @@ test('toBeClassified can be called without threshold', function () {
 
     $testCase->toBeClassified('provider', 'class');
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->threshold)->toBeNull()
         ->and($assertion->provider)->toBe('provider');
 });

--- a/tests/Concerns/CanBeJudgedTest.php
+++ b/tests/Concerns/CanBeJudgedTest.php
@@ -15,9 +15,9 @@ test('toBeJudged creates an assertion with default parameters', function () {
     $result = $testCase->toBeJudged($rubric);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('llm-rubric')
         ->and($assertion->value)->toBe($rubric)
@@ -34,8 +34,8 @@ test('toBeJudged accepts a threshold parameter', function () {
 
     $testCase->toBeJudged($rubric, threshold: $threshold);
 
-    expect($testCase->build()->assertions)->toHaveCount(1);
-    $assertion = $testCase->build()->assertions[0];
+    expect($testCase->build()->assertions())->toHaveCount(1);
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('llm-rubric')
         ->and($assertion->value)->toBe($rubric)
@@ -51,8 +51,8 @@ test('toBeJudged accepts provider parameter', function () {
 
     $testCase->toBeJudged($rubric, provider: $provider);
 
-    expect($testCase->build()->assertions)->toHaveCount(1);
-    $assertion = $testCase->build()->assertions[0];
+    expect($testCase->build()->assertions())->toHaveCount(1);
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('llm-rubric')
         ->and($assertion->value)->toBe($rubric)
@@ -70,8 +70,8 @@ test('toBeJudged accepts both threshold and provider parameters', function () {
 
     $testCase->toBeJudged($rubric, threshold: $threshold, provider: $provider);
 
-    expect($testCase->build()->assertions)->toHaveCount(1);
-    $assertion = $testCase->build()->assertions[0];
+    expect($testCase->build()->assertions())->toHaveCount(1);
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('llm-rubric')
         ->and($assertion->value)->toBe($rubric)
@@ -89,9 +89,9 @@ test('toBeJudged can be chained', function () {
         ->toBeJudged('Second rubric criteria');
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(2);
+        ->and($testCase->build()->assertions())->toHaveCount(2);
 
-    $assertions = $testCase->build()->assertions;
+    $assertions = $testCase->build()->assertions();
     expect($assertions[0]->value)->toBe('First rubric criteria')
         ->and($assertions[1]->value)->toBe('Second rubric criteria')
         ->and($assertions[0]->type)->toBe('llm-rubric')
@@ -109,9 +109,9 @@ test('toBeJudged can be chained with other assertion methods', function () {
         ->toBeJudged('The response should be accurate', threshold: 0.8);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(3);
+        ->and($testCase->build()->assertions())->toHaveCount(3);
 
-    $assertions = $testCase->build()->assertions;
+    $assertions = $testCase->build()->assertions();
     expect($assertions[0]->type)->toBe('llm-rubric')
         ->and($assertions[0]->value)->toBe('The response should be helpful')
         ->and($assertions[1]->type)->toBe('icontains')

--- a/tests/Concerns/CanBeRefusedTest.php
+++ b/tests/Concerns/CanBeRefusedTest.php
@@ -13,9 +13,9 @@ test('toBeRefused creates an is-refusal assertion', function () {
     $result = $testCase->toBeRefused();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('is-refusal')
         ->and($assertion->value)->toBeNull();

--- a/tests/Concerns/CanBeScoredTest.php
+++ b/tests/Concerns/CanBeScoredTest.php
@@ -13,9 +13,9 @@ test('toBeScoredByPi creates a pi assertion', function () {
     $result = $testCase->toBeScoredByPi('Is the response helpful?', threshold: 0.8);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('pi')
         ->and($assertion->value)->toBe('Is the response helpful?')
@@ -28,6 +28,6 @@ test('toBeScoredByPi can be called without threshold', function () {
 
     $testCase->toBeScoredByPi('Is the response helpful?');
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->threshold)->toBeNull();
 });

--- a/tests/Concerns/CanBeSimilarTest.php
+++ b/tests/Concerns/CanBeSimilarTest.php
@@ -13,9 +13,9 @@ test('toBeSimilar creates a similar assertion', function () {
     $result = $testCase->toBeSimilar('expected text');
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('similar')
         ->and($assertion->value)->toBe('expected text');
@@ -28,7 +28,7 @@ test('toBeSimilar accepts array of expected values', function () {
 
     $testCase->toBeSimilar($expected);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toBe($expected);
 });
 
@@ -38,7 +38,7 @@ test('toBeSimilar accepts threshold and provider', function () {
 
     $testCase->toBeSimilar('text', threshold: 0.8, provider: 'huggingface:model');
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->threshold)->toBe(0.8)
         ->and($assertion->provider)->toBe('huggingface:model');
 });
@@ -50,9 +50,9 @@ test('toHaveLevenshtein creates a levenshtein assertion', function () {
     $result = $testCase->toHaveLevenshtein('expected', threshold: 2.0);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('levenshtein')
         ->and($assertion->value)->toBe('expected')
         ->and($assertion->threshold)->toBe(2.0);
@@ -65,9 +65,9 @@ test('toHaveRougeN creates a rouge-n assertion', function () {
     $result = $testCase->toHaveRougeN(1, 'expected', threshold: 0.8);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('rouge-n')
         ->and($assertion->value)->toBe('expected')
         ->and($assertion->threshold)->toBe(0.8)
@@ -82,9 +82,9 @@ test('toHaveFScore creates an f-score assertion', function () {
     $result = $testCase->toHaveFScore('expected', threshold: 0.9);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('f-score')
         ->and($assertion->value)->toBe('expected')
         ->and($assertion->threshold)->toBe(0.9);
@@ -97,9 +97,9 @@ test('toHavePerplexity creates a perplexity assertion', function () {
     $result = $testCase->toHavePerplexity(threshold: 10.0);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('perplexity')
         ->and($assertion->threshold)->toBe(10.0);
 });
@@ -111,9 +111,9 @@ test('toHavePerplexityScore creates a perplexity-score assertion', function () {
     $result = $testCase->toHavePerplexityScore(threshold: 0.5);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('perplexity-score')
         ->and($assertion->threshold)->toBe(0.5);
 });

--- a/tests/Concerns/CanBeValidTest.php
+++ b/tests/Concerns/CanBeValidTest.php
@@ -13,9 +13,9 @@ test('toBeJson creates an is-json assertion', function () {
     $result = $testCase->toBeJson();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('is-json')
         ->and($assertion->value)->toBeNull();
@@ -28,7 +28,7 @@ test('toBeJson accepts schema parameter', function () {
 
     $testCase->toBeJson($schema);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toBe($schema);
 });
 
@@ -39,9 +39,9 @@ test('toBeHtml creates an is-html assertion', function () {
     $result = $testCase->toBeHtml();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('is-html');
 });
 
@@ -52,9 +52,9 @@ test('toBeSql creates an is-sql assertion', function () {
     $result = $testCase->toBeSql();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('is-sql');
 });
 
@@ -65,7 +65,7 @@ test('toBeSql accepts config parameter with databaseType', function () {
 
     $testCase->toBeSql($config);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toBe($config);
 });
 
@@ -76,9 +76,9 @@ test('toBeXml creates an is-xml assertion', function () {
     $result = $testCase->toBeXml();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('is-xml');
 });
 
@@ -89,7 +89,7 @@ test('toBeXml accepts config parameter with requiredElements', function () {
 
     $testCase->toBeXml($config);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toBe($config);
 });
 
@@ -104,5 +104,5 @@ test('can chain validation methods', function () {
         ->toBeXml();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(4);
+        ->and($testCase->build()->assertions())->toHaveCount(4);
 });

--- a/tests/Concerns/CanContainTest.php
+++ b/tests/Concerns/CanContainTest.php
@@ -13,9 +13,9 @@ test('toContain creates an icontains assertion by default', function () {
     $result = $testCase->toContain('test');
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('icontains')
         ->and($assertion->value)->toBe('test');
@@ -27,7 +27,7 @@ test('toContain creates a contains assertion when strict is true', function () {
 
     $testCase->toContain('test', strict: true);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('contains');
 });
 
@@ -40,9 +40,9 @@ test('toContainAll creates an assertion with default parameters', function () {
     $result = $testCase->toContainAll($contains);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('icontains-all')
         ->and($assertion->value)->toBe($contains)
@@ -57,7 +57,7 @@ test('toContainAll creates an icontains-all assertion when strict is false', fun
 
     $testCase->toContainAll($contains, strict: false);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('icontains-all')
         ->and($assertion->value)->toBe($contains)
@@ -72,7 +72,7 @@ test('toContainAll creates a contains-all assertion when strict is true', functi
 
     $testCase->toContainAll($contains, strict: true);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('contains-all')
         ->and($assertion->value)->toBe($contains)
@@ -89,9 +89,9 @@ test('toContainAll can be chained', function () {
         ->toContainAll(['third', 'fourth']);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(2);
+        ->and($testCase->build()->assertions())->toHaveCount(2);
 
-    $assertions = $testCase->build()->assertions;
+    $assertions = $testCase->build()->assertions();
     expect($assertions[0]->value)->toBe(['first', 'second'])
         ->and($assertions[1]->value)->toBe(['third', 'fourth'])
         ->and($assertions[0]->type)->toBe('icontains-all')
@@ -107,9 +107,9 @@ test('toContainAny creates an assertion with default parameters', function () {
     $result = $testCase->toContainAny($contains);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('icontains-any')
         ->and($assertion->value)->toBe($contains)
@@ -124,7 +124,7 @@ test('toContainAny creates an icontains-any assertion when strict is false', fun
 
     $testCase->toContainAny($contains, strict: false);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('icontains-any')
         ->and($assertion->value)->toBe($contains)
@@ -139,7 +139,7 @@ test('toContainAny creates a contains-any assertion when strict is true', functi
 
     $testCase->toContainAny($contains, strict: true);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('contains-any')
         ->and($assertion->value)->toBe($contains)
@@ -156,9 +156,9 @@ test('toContainAny can be chained', function () {
         ->toContainAny(['third', 'fourth']);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(2);
+        ->and($testCase->build()->assertions())->toHaveCount(2);
 
-    $assertions = $testCase->build()->assertions;
+    $assertions = $testCase->build()->assertions();
     expect($assertions[0]->value)->toBe(['first', 'second'])
         ->and($assertions[1]->value)->toBe(['third', 'fourth'])
         ->and($assertions[0]->type)->toBe('icontains-any')
@@ -173,9 +173,9 @@ test('toContainJson creates a contains-json assertion', function () {
     $result = $testCase->toContainJson();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('contains-json')
         ->and($assertion->value)->toBeNull()
@@ -190,7 +190,7 @@ test('toContainJson accepts schema parameter', function () {
 
     $testCase->toContainJson($schema);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toBe($schema);
 });
 
@@ -202,9 +202,9 @@ test('toContainHtml creates a contains-html assertion', function () {
     $result = $testCase->toContainHtml();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('contains-html')
         ->and($assertion->value)->toBeNull()
@@ -219,9 +219,9 @@ test('toContainSql creates a contains-sql assertion', function () {
     $result = $testCase->toContainSql();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('contains-sql')
         ->and($assertion->value)->toBeNull()
@@ -235,7 +235,7 @@ test('toContainSql accepts config parameter with databaseType', function () {
 
     $testCase->toContainSql($config);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toBe($config);
 });
 
@@ -247,9 +247,9 @@ test('toContainXml creates a contains-xml assertion', function () {
     $result = $testCase->toContainXml();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('contains-xml')
         ->and($assertion->value)->toBeNull()
@@ -263,7 +263,7 @@ test('toContainXml accepts config parameter with requiredElements', function () 
 
     $testCase->toContainXml($config);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toBe($config);
 });
 
@@ -279,9 +279,9 @@ test('format-specific assertions can be chained', function () {
         ->toContainXml();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(4);
+        ->and($testCase->build()->assertions())->toHaveCount(4);
 
-    $assertions = $testCase->build()->assertions;
+    $assertions = $testCase->build()->assertions();
     expect($assertions[0]->type)->toBe('contains-json')
         ->and($assertions[1]->type)->toBe('contains-html')
         ->and($assertions[2]->type)->toBe('contains-sql')
@@ -303,9 +303,9 @@ test('all CanContain methods can be mixed and chained', function () {
         ->toContainXml();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(7);
+        ->and($testCase->build()->assertions())->toHaveCount(7);
 
-    $assertions = $testCase->build()->assertions;
+    $assertions = $testCase->build()->assertions();
     expect($assertions[0]->type)->toBe('icontains')
         ->and($assertions[1]->type)->toBe('icontains-all')
         ->and($assertions[2]->type)->toBe('icontains-any')

--- a/tests/Concerns/CanEncloseTest.php
+++ b/tests/Concerns/CanEncloseTest.php
@@ -35,9 +35,9 @@ test('to method can be used to add assertions', function () {
     });
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(2)
-        ->and($testCase->build()->assertions[0])->toBeInstanceOf(Assertion::class)
-        ->and($testCase->build()->assertions[1])->toBeInstanceOf(Assertion::class);
+        ->and($testCase->build()->assertions())->toHaveCount(2)
+        ->and($testCase->build()->assertions()[0])->toBeInstanceOf(Assertion::class)
+        ->and($testCase->build()->assertions()[1])->toBeInstanceOf(Assertion::class);
 });
 
 test('to method can be chained', function () {
@@ -50,7 +50,7 @@ test('to method can be chained', function () {
         ->to(fn (TestCase $tc) => $tc->toContain('second'));
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(2);
+        ->and($testCase->build()->assertions())->toHaveCount(2);
 });
 
 test('group method is an alias for to method', function () {
@@ -66,7 +66,7 @@ test('group method is an alias for to method', function () {
 
     expect($callbackExecuted)->toBeTrue()
         ->and($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 });
 
 test('group method can be chained', function () {
@@ -79,7 +79,7 @@ test('group method can be chained', function () {
         ->group(fn (TestCase $tc) => $tc->toContain('second'));
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(2);
+        ->and($testCase->build()->assertions())->toHaveCount(2);
 });
 
 test('to and group methods can be mixed', function () {
@@ -93,20 +93,7 @@ test('to and group methods can be mixed', function () {
         ->to(fn (TestCase $tc) => $tc->toContain('third'));
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(3);
-});
-
-test('to method accepts invokable class FQN', function () {
-    $evaluation = new Evaluation(['prompt1', 'prompt2']);
-    $variables = ['key1' => 'value1'];
-    $testCase = new TestCase($variables, $evaluation);
-
-    $result = $testCase->to(InvokableTestClass::class);
-
-    expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('icontains')
-        ->and($testCase->build()->assertions[0]->value)->toBe('invokable');
+        ->and($testCase->build()->assertions())->toHaveCount(3);
 });
 
 test('to method accepts invokable class instance', function () {
@@ -117,31 +104,30 @@ test('to method accepts invokable class instance', function () {
     $result = $testCase->to(new InvokableTestClass);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('icontains')
-        ->and($testCase->build()->assertions[0]->value)->toBe('invokable');
+        ->and($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('icontains')
+        ->and($testCase->build()->assertions()[0]->value)->toBe('invokable');
 });
 
-test('to method throws exception for non-invokable class FQN', function () {
+test('group method accepts invokable class instance', function () {
     $evaluation = new Evaluation(['prompt1', 'prompt2']);
     $variables = ['key1' => 'value1'];
     $testCase = new TestCase($variables, $evaluation);
 
-    $testCase->to(NonInvokableTestClass::class);
-})->throws(InvalidArgumentException::class, 'must be callable or an invokable class');
-
-test('group method accepts invokable class FQN', function () {
-    $evaluation = new Evaluation(['prompt1', 'prompt2']);
-    $variables = ['key1' => 'value1'];
-    $testCase = new TestCase($variables, $evaluation);
-
-    $result = $testCase->group(InvokableTestClass::class);
+    $result = $testCase->group(new InvokableTestClass);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('icontains')
-        ->and($testCase->build()->assertions[0]->value)->toBe('invokable');
+        ->and($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('icontains')
+        ->and($testCase->build()->assertions()[0]->value)->toBe('invokable');
 });
+
+test('to method throws exception for unknown string that is not a named group', function () {
+    $evaluation = new Evaluation(['prompt1', 'prompt2']);
+    $testCase = new TestCase([], $evaluation);
+
+    $testCase->to('unknown group');
+})->throws(InvalidArgumentException::class, "Assertion group 'unknown group' not found. Register it using assertion().");
 
 test('to method can use named assertion group without arguments', function () {
     EvaluationRegistry::clear();
@@ -158,11 +144,11 @@ test('to method can use named assertion group without arguments', function () {
     $built = $testCase->build();
 
     expect($result)->toBe($testCase)
-        ->and($built->assertions)->toHaveCount(2)
-        ->and($built->assertions[0]->type)->toBe('icontains')
-        ->and($built->assertions[0]->value)->toBe('hello')
-        ->and($built->assertions[1]->type)->toBe('llm-rubric')
-        ->and($built->assertions[1]->value)->toBe('friendly');
+        ->and($built->assertions())->toHaveCount(2)
+        ->and($built->assertions()[0]->type)->toBe('icontains')
+        ->and($built->assertions()[0]->value)->toBe('hello')
+        ->and($built->assertions()[1]->type)->toBe('llm-rubric')
+        ->and($built->assertions()[1]->value)->toBe('friendly');
 });
 
 test('to method can use named assertion group with arguments', function () {
@@ -181,9 +167,9 @@ test('to method can use named assertion group with arguments', function () {
     $built = $testCase->build();
 
     expect($result)->toBe($testCase)
-        ->and($built->assertions)->toHaveCount(2)
-        ->and($built->assertions[0]->value)->toBe('gentle')
-        ->and($built->assertions[1]->value)->toBe('be gentle');
+        ->and($built->assertions())->toHaveCount(2)
+        ->and($built->assertions()[0]->value)->toBe('gentle')
+        ->and($built->assertions()[1]->value)->toBe('be gentle');
 });
 
 test('group method can use named assertion group', function () {
@@ -200,9 +186,9 @@ test('group method can use named assertion group', function () {
     $built = $testCase->build();
 
     expect($result)->toBe($testCase)
-        ->and($built->assertions)->toHaveCount(1)
-        ->and($built->assertions[0]->type)->toBe('icontains')
-        ->and($built->assertions[0]->value)->toBe('please');
+        ->and($built->assertions())->toHaveCount(1)
+        ->and($built->assertions()[0]->type)->toBe('icontains')
+        ->and($built->assertions()[0]->value)->toBe('please');
 });
 
 class InvokableTestClass
@@ -210,13 +196,5 @@ class InvokableTestClass
     public function __invoke(TestCase $testCase): void
     {
         $testCase->toContain('invokable');
-    }
-}
-
-class NonInvokableTestClass
-{
-    public function handle(TestCase $testCase): void
-    {
-        $testCase->toContain('non-invokable');
     }
 }

--- a/tests/Concerns/CanEqualTest.php
+++ b/tests/Concerns/CanEqualTest.php
@@ -15,9 +15,9 @@ test('toEqual creates an assertion with default parameters', function () {
     $result = $testCase->toEqual($expectedValue);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
 
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('equals')
@@ -35,9 +35,9 @@ test('toEqual can be chained', function () {
         ->toEqual('second value');
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(2);
+        ->and($testCase->build()->assertions())->toHaveCount(2);
 
-    $assertions = $testCase->build()->assertions;
+    $assertions = $testCase->build()->assertions();
 
     expect($assertions[0]->value)->toBe('first value')
         ->and($assertions[1]->value)->toBe('second value')
@@ -51,8 +51,8 @@ test('toEqual accepts integer values', function () {
 
     $testCase->toEqual(42);
 
-    expect($testCase->build()->assertions)->toHaveCount(1);
-    $assertion = $testCase->build()->assertions[0];
+    expect($testCase->build()->assertions())->toHaveCount(1);
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('equals')
         ->and($assertion->value)->toBe(42);
 });
@@ -63,8 +63,8 @@ test('toEqual accepts float values', function () {
 
     $testCase->toEqual(3.14);
 
-    expect($testCase->build()->assertions)->toHaveCount(1);
-    $assertion = $testCase->build()->assertions[0];
+    expect($testCase->build()->assertions())->toHaveCount(1);
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('equals')
         ->and($assertion->value)->toBe(3.14);
 });
@@ -75,8 +75,8 @@ test('toEqual accepts boolean values', function () {
 
     $testCase->toEqual(true);
 
-    expect($testCase->build()->assertions)->toHaveCount(1);
-    $assertion = $testCase->build()->assertions[0];
+    expect($testCase->build()->assertions())->toHaveCount(1);
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('equals')
         ->and($assertion->value)->toBe(true);
 });
@@ -88,8 +88,8 @@ test('toEqual accepts array values', function () {
 
     $testCase->toEqual($expectedArray);
 
-    expect($testCase->build()->assertions)->toHaveCount(1);
-    $assertion = $testCase->build()->assertions[0];
+    expect($testCase->build()->assertions())->toHaveCount(1);
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('equals')
         ->and($assertion->value)->toBe($expectedArray);
 });
@@ -100,8 +100,8 @@ test('toEqual accepts null values', function () {
 
     $testCase->toEqual(null);
 
-    expect($testCase->build()->assertions)->toHaveCount(1);
-    $assertion = $testCase->build()->assertions[0];
+    expect($testCase->build()->assertions())->toHaveCount(1);
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('equals')
         ->and($assertion->value)->toBeNull();
 });
@@ -112,8 +112,8 @@ test('toBe is an alias for toEqual', function () {
 
     $testCase->toBe('first value');
 
-    expect($testCase->build()->assertions)->toHaveCount(1);
-    $assertion = $testCase->build()->assertions[0];
+    expect($testCase->build()->assertions())->toHaveCount(1);
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('equals')
         ->and($assertion->value)->toBe('first value');
 });

--- a/tests/Concerns/CanHaveCustomValidationTest.php
+++ b/tests/Concerns/CanHaveCustomValidationTest.php
@@ -14,9 +14,9 @@ test('toPassJavascript creates a javascript assertion', function () {
     $result = $testCase->toPassJavascript($code);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('javascript')
         ->and($assertion->value)->toBe($code);
@@ -29,7 +29,7 @@ test('toPassJavascript accepts threshold parameter', function () {
 
     $testCase->toPassJavascript($code, threshold: 0.5);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->threshold)->toBe(0.5);
 });
 
@@ -41,7 +41,7 @@ test('toPassJavascript accepts config parameter', function () {
 
     $testCase->toPassJavascript($code, config: $config);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->config)->toBe($config);
 });
 
@@ -53,9 +53,9 @@ test('toPassPython creates a python assertion', function () {
     $result = $testCase->toPassPython($code);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('python')
         ->and($assertion->value)->toBe($code);
@@ -68,7 +68,7 @@ test('toPassPython accepts threshold parameter', function () {
 
     $testCase->toPassPython($code, threshold: 0.5);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->threshold)->toBe(0.5);
 });
 
@@ -80,7 +80,7 @@ test('toPassPython accepts config parameter', function () {
 
     $testCase->toPassPython($code, config: $config);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->config)->toBe($config);
 });
 
@@ -92,9 +92,9 @@ test('toPassWebhook creates a webhook assertion', function () {
     $result = $testCase->toPassWebhook($url);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('webhook')
         ->and($assertion->value)->toBe($url);

--- a/tests/Concerns/CanHaveCustomValidationTest.php
+++ b/tests/Concerns/CanHaveCustomValidationTest.php
@@ -42,7 +42,10 @@ test('toPassJavascript accepts config parameter', function () {
     $testCase->toPassJavascript($code, config: $config);
 
     $assertion = $testCase->build()->assertions()[0];
-    expect($assertion->config)->toBe($config);
+    // User config is preserved alongside internal assertion_id
+    expect($assertion->config)->toHaveKey('minLength')
+        ->and($assertion->config['minLength'])->toBe(10)
+        ->and($assertion->config)->toHaveKey(Assertion::INTERNAL_CONFIG_KEY);
 });
 
 test('toPassPython creates a python assertion', function () {
@@ -81,7 +84,10 @@ test('toPassPython accepts config parameter', function () {
     $testCase->toPassPython($code, config: $config);
 
     $assertion = $testCase->build()->assertions()[0];
-    expect($assertion->config)->toBe($config);
+    // User config is preserved alongside internal assertion_id
+    expect($assertion->config)->toHaveKey('minLength')
+        ->and($assertion->config['minLength'])->toBe(10)
+        ->and($assertion->config)->toHaveKey(Assertion::INTERNAL_CONFIG_KEY);
 });
 
 test('toPassWebhook creates a webhook assertion', function () {

--- a/tests/Concerns/CanHaveFinishReasonTest.php
+++ b/tests/Concerns/CanHaveFinishReasonTest.php
@@ -14,9 +14,9 @@ test('toHaveFinishReason creates a finish-reason assertion', function () {
     $result = $testCase->toHaveFinishReason('stop');
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('finish-reason')
         ->and($assertion->value)->toBe('stop');
@@ -28,7 +28,7 @@ test('toHaveFinishReason accepts FinishReason enum', function () {
 
     $testCase->toHaveFinishReason(FinishReason::Stop);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toBe('stop');
 });
 
@@ -38,7 +38,7 @@ test('toHaveFinishReason accepts different reason values', function () {
 
     $testCase->toHaveFinishReason('length');
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toBe('length');
 });
 
@@ -49,9 +49,9 @@ test('toHaveFinishReasonStop creates assertion with stop reason', function () {
     $result = $testCase->toHaveFinishReasonStop();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('finish-reason')
         ->and($assertion->value)->toBe('stop');
 });
@@ -63,9 +63,9 @@ test('toHaveFinishReasonLength creates assertion with length reason', function (
     $result = $testCase->toHaveFinishReasonLength();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('finish-reason')
         ->and($assertion->value)->toBe('length');
 });
@@ -77,9 +77,9 @@ test('toHaveFinishReasonContentFilter creates assertion with content_filter reas
     $result = $testCase->toHaveFinishReasonContentFilter();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('finish-reason')
         ->and($assertion->value)->toBe('content_filter');
 });
@@ -91,9 +91,9 @@ test('toHaveFinishReasonToolCalls creates assertion with tool_calls reason', fun
     $result = $testCase->toHaveFinishReasonToolCalls();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('finish-reason')
         ->and($assertion->value)->toBe('tool_calls');
 });

--- a/tests/Concerns/CanHaveFunctionCallsTest.php
+++ b/tests/Concerns/CanHaveFunctionCallsTest.php
@@ -13,9 +13,9 @@ test('toHaveValidFunctionCall creates an is-valid-function-call assertion', func
     $result = $testCase->toHaveValidFunctionCall();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('is-valid-function-call');
 });
@@ -27,7 +27,7 @@ test('toHaveValidFunctionCall accepts schema parameter', function () {
 
     $testCase->toHaveValidFunctionCall($schema);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toBe($schema);
 });
 
@@ -38,9 +38,9 @@ test('toHaveValidOpenaiFunctionCall creates an is-valid-openai-function-call ass
     $result = $testCase->toHaveValidOpenaiFunctionCall();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('is-valid-openai-function-call');
 });
 
@@ -51,9 +51,9 @@ test('toHaveValidOpenaiToolsCall creates an is-valid-openai-tools-call assertion
     $result = $testCase->toHaveValidOpenaiToolsCall();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('is-valid-openai-tools-call');
 });
 
@@ -65,9 +65,9 @@ test('toHaveToolCallF1 creates a tool-call-f1 assertion', function () {
     $result = $testCase->toHaveToolCallF1($expected, threshold: 0.8);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('tool-call-f1')
         ->and($assertion->value)->toBe($expected)
         ->and($assertion->threshold)->toBe(0.8);

--- a/tests/Concerns/CanHavePerformanceTest.php
+++ b/tests/Concerns/CanHavePerformanceTest.php
@@ -13,9 +13,9 @@ test('toHaveCost creates a cost assertion', function () {
     $result = $testCase->toHaveCost(0.01);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('cost')
         ->and($assertion->threshold)->toBe(0.01);
@@ -28,9 +28,9 @@ test('toHaveLatency creates a latency assertion', function () {
     $result = $testCase->toHaveLatency(1000);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('latency')
         ->and($assertion->threshold)->toBe(1000.0);
@@ -45,5 +45,5 @@ test('can chain performance methods', function () {
         ->toHaveLatency(1000);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(2);
+        ->and($testCase->build()->assertions())->toHaveCount(2);
 });

--- a/tests/Concerns/CanHaveTracesTest.php
+++ b/tests/Concerns/CanHaveTracesTest.php
@@ -14,9 +14,9 @@ test('toHaveTraceSpanCount creates a trace-span-count assertion', function () {
     $result = $testCase->toHaveTraceSpanCount($patterns, min: 1, max: 5);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('trace-span-count')
         ->and($assertion->value)->toHaveKey('patterns')
@@ -34,7 +34,7 @@ test('toHaveTraceSpanCount can be called without min/max', function () {
 
     $testCase->toHaveTraceSpanCount($patterns);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->value)->toHaveKey('patterns')
         ->and($assertion->value)->not->toHaveKey('min')
         ->and($assertion->value)->not->toHaveKey('max');
@@ -48,9 +48,9 @@ test('toHaveTraceSpanDuration creates a trace-span-duration assertion', function
     $result = $testCase->toHaveTraceSpanDuration($patterns, percentile: 0.95, maxDuration: 1000.0);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion->type)->toBe('trace-span-duration')
         ->and($assertion->value)->toHaveKey('patterns')
         ->and($assertion->value)->toHaveKey('percentile')
@@ -66,9 +66,9 @@ test('toHaveTraceErrorSpans creates a trace-error-spans assertion', function () 
     $result = $testCase->toHaveTraceErrorSpans();
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('trace-error-spans');
 });

--- a/tests/Concerns/CanMatchTest.php
+++ b/tests/Concerns/CanMatchTest.php
@@ -13,9 +13,9 @@ test('startsWith creates a starts-with assertion', function () {
     $result = $testCase->startsWith('Hello');
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('starts-with')
         ->and($assertion->value)->toBe('Hello')
@@ -29,9 +29,9 @@ test('toMatchRegex creates a regex assertion', function () {
     $result = $testCase->toMatchRegex('/\d+/');
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1);
 
-    $assertion = $testCase->build()->assertions[0];
+    $assertion = $testCase->build()->assertions()[0];
     expect($assertion)->toBeInstanceOf(Assertion::class)
         ->and($assertion->type)->toBe('regex')
         ->and($assertion->value)->toBe('/\d+/')
@@ -47,5 +47,5 @@ test('can chain match methods', function () {
         ->toMatchRegex('/\d+/');
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(2);
+        ->and($testCase->build()->assertions())->toHaveCount(2);
 });

--- a/tests/Concerns/CanValidateJsonTest.php
+++ b/tests/Concerns/CanValidateJsonTest.php
@@ -14,9 +14,9 @@ describe('toEqualJson', function () {
         $result = $testCase->toEqualJson(['name' => 'John', 'age' => 30]);
 
         expect($result)->toBe($testCase)
-            ->and($testCase->build()->assertions)->toHaveCount(1);
+            ->and($testCase->build()->assertions())->toHaveCount(1);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion)->toBeInstanceOf(Assertion::class)
             ->and($assertion->type)->toBe('javascript')
             ->and($assertion->value)->toContain('deepEqual');
@@ -29,7 +29,7 @@ describe('toEqualJson', function () {
 
         $testCase->toEqualJson($expected);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"name":"John"')
             ->and($assertion->value)->toContain('"age":30');
     });
@@ -40,7 +40,7 @@ describe('toEqualJson', function () {
 
         $testCase->not->toEqualJson(['name' => 'John']);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->type)->toBe('not-javascript');
     });
 
@@ -58,7 +58,7 @@ describe('toEqualJson', function () {
 
         $testCase->toEqualJson($expected);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('Amsterdam')
             ->and($assertion->value)->toContain('address');
     });
@@ -70,7 +70,7 @@ describe('toEqualJson', function () {
 
         $testCase->toEqualJson($expected);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('[1,2,3]');
     });
 
@@ -80,7 +80,7 @@ describe('toEqualJson', function () {
 
         $testCase->toEqualJson(['items' => []]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"items":[]');
     });
 });
@@ -93,9 +93,9 @@ describe('toMatchJsonStructure', function () {
         $result = $testCase->toMatchJsonStructure(['name', 'age']);
 
         expect($result)->toBe($testCase)
-            ->and($testCase->build()->assertions)->toHaveCount(1);
+            ->and($testCase->build()->assertions())->toHaveCount(1);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion)->toBeInstanceOf(Assertion::class)
             ->and($assertion->type)->toBe('javascript')
             ->and($assertion->value)->toContain('checkStructure');
@@ -107,7 +107,7 @@ describe('toMatchJsonStructure', function () {
 
         $testCase->toMatchJsonStructure(['name', 'age', 'email']);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"name"')
             ->and($assertion->value)->toContain('"age"')
             ->and($assertion->value)->toContain('"email"');
@@ -122,7 +122,7 @@ describe('toMatchJsonStructure', function () {
             'address' => ['city', 'street'],
         ]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"address"')
             ->and($assertion->value)->toContain('"city"')
             ->and($assertion->value)->toContain('"street"');
@@ -138,7 +138,7 @@ describe('toMatchJsonStructure', function () {
             ],
         ]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"*"')
             ->and($assertion->value)->toContain('"id"')
             ->and($assertion->value)->toContain('"name"');
@@ -150,7 +150,7 @@ describe('toMatchJsonStructure', function () {
 
         $testCase->not->toMatchJsonStructure(['forbidden_key']);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->type)->toBe('not-javascript');
     });
 });
@@ -163,9 +163,9 @@ describe('toHaveJsonFragment', function () {
         $result = $testCase->toHaveJsonFragment(['name' => 'John']);
 
         expect($result)->toBe($testCase)
-            ->and($testCase->build()->assertions)->toHaveCount(1);
+            ->and($testCase->build()->assertions())->toHaveCount(1);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion)->toBeInstanceOf(Assertion::class)
             ->and($assertion->type)->toBe('javascript')
             ->and($assertion->value)->toContain('containsFragment');
@@ -177,7 +177,7 @@ describe('toHaveJsonFragment', function () {
 
         $testCase->toHaveJsonFragment(['name' => 'John', 'active' => true]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"name":"John"')
             ->and($assertion->value)->toContain('"active":true');
     });
@@ -188,7 +188,7 @@ describe('toHaveJsonFragment', function () {
 
         $testCase->not->toHaveJsonFragment(['secret' => 'value']);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->type)->toBe('not-javascript');
     });
 
@@ -200,7 +200,7 @@ describe('toHaveJsonFragment', function () {
             'address' => ['city' => 'Amsterdam'],
         ]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('Amsterdam');
     });
 
@@ -210,7 +210,7 @@ describe('toHaveJsonFragment', function () {
 
         $testCase->toHaveJsonFragment(['active' => false]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"active":false');
     });
 });
@@ -226,9 +226,9 @@ describe('toHaveJsonFragments', function () {
         ]);
 
         expect($result)->toBe($testCase)
-            ->and($testCase->build()->assertions)->toHaveCount(1);
+            ->and($testCase->build()->assertions())->toHaveCount(1);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion)->toBeInstanceOf(Assertion::class)
             ->and($assertion->type)->toBe('javascript');
     });
@@ -242,7 +242,7 @@ describe('toHaveJsonFragments', function () {
             ['city' => 'Amsterdam'],
         ]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"name":"John"')
             ->and($assertion->value)->toContain('"city":"Amsterdam"');
     });
@@ -255,7 +255,7 @@ describe('toHaveJsonFragments', function () {
             ['secret' => 'value'],
         ]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->type)->toBe('not-javascript');
     });
 });
@@ -268,9 +268,9 @@ describe('toHaveJsonPath', function () {
         $result = $testCase->toHaveJsonPath('name');
 
         expect($result)->toBe($testCase)
-            ->and($testCase->build()->assertions)->toHaveCount(1);
+            ->and($testCase->build()->assertions())->toHaveCount(1);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion)->toBeInstanceOf(Assertion::class)
             ->and($assertion->type)->toBe('javascript')
             ->and($assertion->value)->toContain('pathParts');
@@ -282,7 +282,7 @@ describe('toHaveJsonPath', function () {
 
         $testCase->toHaveJsonPath('user.name');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"user"')
             ->and($assertion->value)->toContain('"name"');
     });
@@ -293,7 +293,7 @@ describe('toHaveJsonPath', function () {
 
         $testCase->toHaveJsonPath('name', 'John');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"John"')
             ->and($assertion->value)->toContain('hasExpected = true');
     });
@@ -304,7 +304,7 @@ describe('toHaveJsonPath', function () {
 
         $testCase->toHaveJsonPath('deletedAt', null);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('hasExpected = true')
             ->and($assertion->value)->toContain('const expected = null');
     });
@@ -315,7 +315,7 @@ describe('toHaveJsonPath', function () {
 
         $testCase->toHaveJsonPath('address.city.name');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('["address","city","name"]');
     });
 
@@ -325,7 +325,7 @@ describe('toHaveJsonPath', function () {
 
         $testCase->not->toHaveJsonPath('secret');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->type)->toBe('not-javascript');
     });
 
@@ -335,7 +335,7 @@ describe('toHaveJsonPath', function () {
 
         $testCase->toHaveJsonPath('people.0.name');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('["people","0","name"]')
             ->and($assertion->value)->toContain('parseInt(current, 10)');
     });
@@ -346,7 +346,7 @@ describe('toHaveJsonPath', function () {
 
         $testCase->toHaveJsonPath('people.1.name', 'Jane');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('["people","1","name"]')
             ->and($assertion->value)->toContain('"Jane"');
     });
@@ -357,7 +357,7 @@ describe('toHaveJsonPath', function () {
 
         $testCase->toHaveJsonPath('people.*.name');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('["people","*","name"]')
             ->and($assertion->value)->toContain("current === '*'")
             ->and($assertion->value)->toContain('flatMap');
@@ -369,7 +369,7 @@ describe('toHaveJsonPath', function () {
 
         $testCase->toHaveJsonPath('items.*.status', 'active');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('["items","*","status"]')
             ->and($assertion->value)->toContain('"active"')
             ->and($assertion->value)->toContain('values.every');
@@ -381,7 +381,7 @@ describe('toHaveJsonPath', function () {
 
         $testCase->toHaveJsonPath('data.users.*.addresses.*.city');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('["data","users","*","addresses","*","city"]');
     });
 });
@@ -394,9 +394,9 @@ describe('toHaveJsonPaths', function () {
         $result = $testCase->toHaveJsonPaths(['name', 'age']);
 
         expect($result)->toBe($testCase)
-            ->and($testCase->build()->assertions)->toHaveCount(1);
+            ->and($testCase->build()->assertions())->toHaveCount(1);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion)->toBeInstanceOf(Assertion::class)
             ->and($assertion->type)->toBe('javascript');
     });
@@ -407,7 +407,7 @@ describe('toHaveJsonPaths', function () {
 
         $testCase->toHaveJsonPaths(['name', 'age', 'address.city']);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"name"')
             ->and($assertion->value)->toContain('"age"')
             ->and($assertion->value)->toContain('"address.city"')
@@ -423,7 +423,7 @@ describe('toHaveJsonPaths', function () {
             'age' => 30,
         ]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"name":"John"')
             ->and($assertion->value)->toContain('"age":30')
             ->and($assertion->value)->toContain('isAssociative = true');
@@ -435,7 +435,7 @@ describe('toHaveJsonPaths', function () {
 
         $testCase->not->toHaveJsonPaths(['secret', 'password']);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->type)->toBe('not-javascript');
     });
 
@@ -448,7 +448,7 @@ describe('toHaveJsonPaths', function () {
             'user.address.city' => 'Amsterdam',
         ]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"user.name":"John"')
             ->and($assertion->value)->toContain('"user.address.city":"Amsterdam"');
     });
@@ -459,7 +459,7 @@ describe('toHaveJsonPaths', function () {
 
         $testCase->toHaveJsonPaths(['items.*.id', 'items.*.name']);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"items.*.id"')
             ->and($assertion->value)->toContain('"items.*.name"');
     });
@@ -472,7 +472,7 @@ describe('toHaveJsonPaths', function () {
             'items.*.type' => 'product',
         ]);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"items.*.type":"product"');
     });
 });
@@ -485,9 +485,9 @@ describe('toHaveJsonType', function () {
         $result = $testCase->toHaveJsonType('name', 'string');
 
         expect($result)->toBe($testCase)
-            ->and($testCase->build()->assertions)->toHaveCount(1);
+            ->and($testCase->build()->assertions())->toHaveCount(1);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion)->toBeInstanceOf(Assertion::class)
             ->and($assertion->type)->toBe('javascript')
             ->and($assertion->value)->toContain('expectedType');
@@ -499,7 +499,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->toHaveJsonType('name', 'string');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"string"');
     });
 
@@ -509,7 +509,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->toHaveJsonType('age', 'number');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"number"');
     });
 
@@ -519,7 +519,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->toHaveJsonType('active', 'boolean');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"boolean"');
     });
 
@@ -529,7 +529,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->toHaveJsonType('items', 'array');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"array"');
     });
 
@@ -539,7 +539,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->toHaveJsonType('address', 'object');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"object"');
     });
 
@@ -549,7 +549,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->toHaveJsonType('deletedAt', 'null');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('"null"');
     });
 
@@ -559,7 +559,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->toHaveJsonType('address.city', 'string');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('["address","city"]');
     });
 
@@ -569,7 +569,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->not->toHaveJsonType('age', 'string');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->type)->toBe('not-javascript');
     });
 
@@ -579,7 +579,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->toHaveJsonType('items.0.price', 'number');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('["items","0","price"]')
             ->and($assertion->value)->toContain('"number"');
     });
@@ -590,7 +590,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->toHaveJsonType('people.*.age', 'number');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('["people","*","age"]')
             ->and($assertion->value)->toContain('"number"')
             ->and($assertion->value)->toContain('values.every');
@@ -602,7 +602,7 @@ describe('toHaveJsonType', function () {
 
         $testCase->toHaveJsonType('items.*.value', 'string');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('actualTypes')
             ->and($assertion->value)->toContain('new Set');
     });
@@ -620,9 +620,9 @@ describe('chaining and integration', function () {
             ->toHaveJsonType('name', 'string');
 
         expect($result)->toBe($testCase)
-            ->and($testCase->build()->assertions)->toHaveCount(4);
+            ->and($testCase->build()->assertions())->toHaveCount(4);
 
-        $assertions = $testCase->build()->assertions;
+        $assertions = $testCase->build()->assertions();
         expect($assertions[0]->type)->toBe('javascript')
             ->and($assertions[1]->type)->toBe('javascript')
             ->and($assertions[2]->type)->toBe('javascript')
@@ -639,9 +639,9 @@ describe('chaining and integration', function () {
             ->toContain('John');
 
         expect($result)->toBe($testCase)
-            ->and($testCase->build()->assertions)->toHaveCount(3);
+            ->and($testCase->build()->assertions())->toHaveCount(3);
 
-        $assertions = $testCase->build()->assertions;
+        $assertions = $testCase->build()->assertions();
         expect($assertions[0]->type)->toBe('is-json')
             ->and($assertions[1]->type)->toBe('javascript')
             ->and($assertions[2]->type)->toBe('icontains');
@@ -653,7 +653,7 @@ describe('chaining and integration', function () {
 
         $testCase->toEqualJson(['test' => 'value']);
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('```(?:json)?');
     });
 
@@ -663,7 +663,7 @@ describe('chaining and integration', function () {
 
         $testCase->toHaveJsonPath('name');
 
-        $assertion = $testCase->build()->assertions[0];
+        $assertion = $testCase->build()->assertions()[0];
         expect($assertion->value)->toContain('Output is not valid JSON');
     });
 });

--- a/tests/EvaluationTest.php
+++ b/tests/EvaluationTest.php
@@ -293,7 +293,7 @@ test('alwaysExpect method can be chained with assertion methods', function () {
         ->toBeJudged('the source and output language are always mentioned');
 
     expect($result)->toBeInstanceOf(TestCase::class)
-        ->and($result->build()->assertions)->toHaveCount(2);
+        ->and($result->build()->assertions())->toHaveCount(2);
 });
 
 test('default test case is NOT added to testCases array', function () {
@@ -345,7 +345,7 @@ test('expect method callback can be used to add assertions', function () {
             ->toContain('value');
     });
 
-    expect($testCase->build()->assertions)->toHaveCount(2);
+    expect($testCase->build()->assertions())->toHaveCount(2);
 });
 
 test('expect method works without callback', function () {
@@ -393,7 +393,7 @@ test('alwaysExpect method callback can be used to add assertions', function () {
             ->toBeJudged('should be professional');
     });
 
-    expect($testCase->build()->assertions)->toHaveCount(2);
+    expect($testCase->build()->assertions())->toHaveCount(2);
 });
 
 test('alwaysExpect method callback is called on subsequent calls with existing test case', function () {
@@ -413,7 +413,7 @@ test('alwaysExpect method callback is called on subsequent calls with existing t
 
     expect($testCase1)->toBe($testCase2)
         ->and($callbackCount)->toBe(2)
-        ->and($testCase1->build()->assertions)->toHaveCount(2);
+        ->and($testCase1->build()->assertions())->toHaveCount(2);
 });
 
 test('alwaysExpect method works without callback', function () {

--- a/tests/Exceptions/PromptAssertionFailedExceptionTest.php
+++ b/tests/Exceptions/PromptAssertionFailedExceptionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use KevinPijning\Prompt\Exceptions\PromptAssertionFailedException;
+use KevinPijning\Prompt\Helpers\SourceLocation;
+
+test('PromptAssertionFailedException can be instantiated with SourceLocation and message', function () {
+    $location = new SourceLocation('/path/to/file.php', 42);
+    $exception = new PromptAssertionFailedException($location, 'Test error message');
+
+    expect($exception->getMessage())->toBe('Test error message')
+        ->and($exception->getSourceLocation())->toBe($location);
+});
+
+test('toCollisionEditor returns Frame with correct file and line', function () {
+    $location = new SourceLocation('/path/to/test.php', 123);
+    $exception = new PromptAssertionFailedException($location, 'Error');
+
+    $frame = $exception->toCollisionEditor();
+
+    expect($frame->getFile())->toBe('/path/to/test.php')
+        ->and($frame->getLine())->toBe(123);
+});
+
+test('getSourceLocation returns the provided SourceLocation', function () {
+    $location = new SourceLocation('/another/path.php', 99);
+    $exception = new PromptAssertionFailedException($location, 'Message');
+
+    expect($exception->getSourceLocation())->toBeInstanceOf(SourceLocation::class)
+        ->and($exception->getSourceLocation()->file)->toBe('/another/path.php')
+        ->and($exception->getSourceLocation()->line)->toBe(99);
+});
+
+test('PromptAssertionFailedException extends AssertionFailedError', function () {
+    $location = new SourceLocation('/path/to/file.php', 1);
+    $exception = new PromptAssertionFailedException($location, 'Error');
+
+    expect($exception)->toBeInstanceOf(PHPUnit\Framework\AssertionFailedError::class);
+});

--- a/tests/Helpers/SourceLocationTest.php
+++ b/tests/Helpers/SourceLocationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use KevinPijning\Prompt\Helpers\SourceLocation;
+
+test('constructor sets file and line properties', function () {
+    $location = new SourceLocation('/path/to/test.php', 42);
+
+    expect($location->file)->toBe('/path/to/test.php')
+        ->and($location->line)->toBe(42);
+});
+
+test('isValid returns true for valid file and line', function () {
+    $location = new SourceLocation('/path/to/test.php', 42);
+
+    expect($location->isValid())->toBeTrue();
+});
+
+test('isValid returns false for empty file', function () {
+    $location = new SourceLocation('', 42);
+
+    expect($location->isValid())->toBeFalse();
+});
+
+test('isValid returns false for line zero', function () {
+    $location = new SourceLocation('/path/to/test.php', 0);
+
+    expect($location->isValid())->toBeFalse();
+});
+
+test('isValid returns false for negative line', function () {
+    $location = new SourceLocation('/path/to/test.php', -1);
+
+    expect($location->isValid())->toBeFalse();
+});
+
+test('capture returns SourceLocation from call stack', function () {
+    $location = SourceLocation::capture();
+
+    expect($location)->toBeInstanceOf(SourceLocation::class)
+        ->and($location->file)->toContain('SourceLocationTest.php')
+        ->and($location->line)->toBeGreaterThan(0);
+});
+
+test('fromBacktrace returns first non-filtered frame', function () {
+    $backtrace = [
+        ['file' => '/path/to/project/tests/MyTest.php', 'line' => 42],
+    ];
+
+    $location = SourceLocation::fromBacktrace($backtrace);
+
+    expect($location)->toBeInstanceOf(SourceLocation::class)
+        ->and($location->file)->toBe('/path/to/project/tests/MyTest.php')
+        ->and($location->line)->toBe(42);
+});
+
+test('fromBacktrace skips plugin src frames but not test frames', function () {
+    $backtrace = [
+        ['file' => '/path/to/pest-plugin-prompt/tests/MyTest.php', 'line' => 42],
+    ];
+
+    $location = SourceLocation::fromBacktrace($backtrace);
+
+    expect($location->file)->toBe('/path/to/pest-plugin-prompt/tests/MyTest.php');
+});
+
+test('fromBacktrace skips frames without file or line', function () {
+    $backtrace = [
+        ['function' => 'someFunction'],
+        ['file' => '/path/to/project/tests/MyTest.php', 'line' => 42],
+    ];
+
+    $location = SourceLocation::fromBacktrace($backtrace);
+
+    expect($location->file)->toBe('/path/to/project/tests/MyTest.php');
+});
+
+test('fromBacktrace returns null for empty backtrace', function () {
+    $location = SourceLocation::fromBacktrace([]);
+
+    expect($location)->toBeNull();
+});

--- a/tests/Internal/TestLifecycleTest.php
+++ b/tests/Internal/TestLifecycleTest.php
@@ -396,3 +396,164 @@ test('encodeOutput returns string as-is', function () {
     expect($result)->toBeString()
         ->and($result)->toBe($string);
 });
+
+test('findSourceLocation maps duplicate assertions to correct source locations via ID', function () {
+    // Arrange: two tracked assertions with same type/value but different IDs/locations
+    $location1 = new KevinPijning\Prompt\Helpers\SourceLocation('/path/to/Test.php', 10);
+    $location2 = new KevinPijning\Prompt\Helpers\SourceLocation('/path/to/Test.php', 20);
+
+    $assertion1 = new Assertion(
+        type: 'contains',
+        value: 'hello',
+        config: [Assertion::INTERNAL_CONFIG_KEY => [Assertion::INTERNAL_ASSERTION_ID_KEY => 'id-1']],
+    );
+    $assertion2 = new Assertion(
+        type: 'contains',
+        value: 'hello', // Same type/value!
+        config: [Assertion::INTERNAL_CONFIG_KEY => [Assertion::INTERNAL_ASSERTION_ID_KEY => 'id-2']],
+    );
+
+    $tracked1 = new KevinPijning\Prompt\Internal\TrackedAssertion($assertion1, $location1);
+    $tracked2 = new KevinPijning\Prompt\Internal\TrackedAssertion($assertion2, $location2);
+
+    // Set up TestLifecycle with both tracked assertions via reflection
+    $reflection = new ReflectionClass(TestLifecycle::class);
+    $property = $reflection->getProperty('currentTrackedAssertions');
+    $property->setValue(null, [$tracked1, $tracked2]);
+
+    $method = $reflection->getMethod('findSourceLocation');
+
+    // Act: simulate promptfoo returning a failure for the SECOND assertion (id-2)
+    $returnedAssertion = new Assertion(
+        type: 'contains',
+        value: 'hello',
+        config: [Assertion::INTERNAL_CONFIG_KEY => [Assertion::INTERNAL_ASSERTION_ID_KEY => 'id-2']],
+    );
+
+    $result = $method->invoke(null, $returnedAssertion);
+
+    // Assert: should map to location2 (line 20), NOT location1 (line 10)
+    expect($result->file)->toBe('/path/to/Test.php')
+        ->and($result->line)->toBe(20);
+
+    // Cleanup
+    $property->setValue(null, []);
+});
+
+test('findSourceLocation falls back to type+value when no ID present', function () {
+    // Arrange: tracked assertion without ID
+    $location = new KevinPijning\Prompt\Helpers\SourceLocation('/path/to/Test.php', 15);
+    $assertion = new Assertion(type: 'contains', value: 'test');
+    $tracked = new KevinPijning\Prompt\Internal\TrackedAssertion($assertion, $location);
+
+    $reflection = new ReflectionClass(TestLifecycle::class);
+    $property = $reflection->getProperty('currentTrackedAssertions');
+    $property->setValue(null, [$tracked]);
+
+    $method = $reflection->getMethod('findSourceLocation');
+
+    // Act: returned assertion without ID
+    $returnedAssertion = new Assertion(type: 'contains', value: 'test');
+    $result = $method->invoke(null, $returnedAssertion);
+
+    // Assert: should match by type+value
+    expect($result->file)->toBe('/path/to/Test.php')
+        ->and($result->line)->toBe(15);
+
+    // Cleanup
+    $property->setValue(null, []);
+});
+
+test('findSourceLocation returns fallback when no match found', function () {
+    $reflection = new ReflectionClass(TestLifecycle::class);
+    $property = $reflection->getProperty('currentTrackedAssertions');
+    $property->setValue(null, []);
+
+    $method = $reflection->getMethod('findSourceLocation');
+
+    $returnedAssertion = new Assertion(type: 'contains', value: 'nonexistent');
+    $result = $method->invoke(null, $returnedAssertion);
+
+    // Assert: should return fallback location (TestLifecycle.php)
+    expect($result->file)->toContain('TestLifecycle.php');
+
+    // Cleanup
+    $property->setValue(null, []);
+});
+
+test('collectTrackedAssertions includes default test case assertions', function () {
+    $reflection = new ReflectionClass(TestLifecycle::class);
+    $method = $reflection->getMethod('collectTrackedAssertions');
+
+    // Create tracked assertions for default test case
+    $defaultAssertion = new Assertion(type: 'llm-rubric', value: 'default assertion');
+    $defaultTracked = new KevinPijning\Prompt\Internal\TrackedAssertion(
+        $defaultAssertion,
+        new KevinPijning\Prompt\Helpers\SourceLocation('/path/to/Test.php', 5)
+    );
+
+    // Create tracked assertions for regular test case
+    $regularAssertion = new Assertion(type: 'contains', value: 'regular assertion');
+    $regularTracked = new KevinPijning\Prompt\Internal\TrackedAssertion(
+        $regularAssertion,
+        new KevinPijning\Prompt\Helpers\SourceLocation('/path/to/Test.php', 10)
+    );
+
+    // Build test cases
+    $defaultTestCase = new KevinPijning\Prompt\Internal\BuiltTestCase(
+        variables: ['default' => 'value'],
+        trackedAssertions: [$defaultTracked]
+    );
+
+    $regularTestCase = new KevinPijning\Prompt\Internal\BuiltTestCase(
+        variables: ['key' => 'value'],
+        trackedAssertions: [$regularTracked]
+    );
+
+    // Build evaluation with both default and regular test cases
+    $builtEvaluation = new KevinPijning\Prompt\Internal\BuiltEvaluation(
+        description: 'Test',
+        prompts: ['test prompt'],
+        providers: [],
+        testCases: [$regularTestCase],
+        defaultTestCase: $defaultTestCase
+    );
+
+    $result = $method->invoke(null, $builtEvaluation);
+
+    // Should include both default and regular assertions
+    expect($result)->toHaveCount(2)
+        ->and($result[0]->assertion->type)->toBe('llm-rubric')
+        ->and($result[0]->assertion->value)->toBe('default assertion')
+        ->and($result[1]->assertion->type)->toBe('contains')
+        ->and($result[1]->assertion->value)->toBe('regular assertion');
+});
+
+test('collectTrackedAssertions works without default test case', function () {
+    $reflection = new ReflectionClass(TestLifecycle::class);
+    $method = $reflection->getMethod('collectTrackedAssertions');
+
+    $regularAssertion = new Assertion(type: 'contains', value: 'test');
+    $regularTracked = new KevinPijning\Prompt\Internal\TrackedAssertion(
+        $regularAssertion,
+        new KevinPijning\Prompt\Helpers\SourceLocation('/path/to/Test.php', 10)
+    );
+
+    $regularTestCase = new KevinPijning\Prompt\Internal\BuiltTestCase(
+        variables: ['key' => 'value'],
+        trackedAssertions: [$regularTracked]
+    );
+
+    $builtEvaluation = new KevinPijning\Prompt\Internal\BuiltEvaluation(
+        description: 'Test',
+        prompts: ['test prompt'],
+        providers: [],
+        testCases: [$regularTestCase],
+        defaultTestCase: null
+    );
+
+    $result = $method->invoke(null, $builtEvaluation);
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0]->assertion->type)->toBe('contains');
+});

--- a/tests/Internal/TrackedAssertionTest.php
+++ b/tests/Internal/TrackedAssertionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use KevinPijning\Prompt\Assertion;
+use KevinPijning\Prompt\Helpers\SourceLocation;
+use KevinPijning\Prompt\Internal\TrackedAssertion;
+
+test('constructor sets assertion and sourceLocation properties', function () {
+    $assertion = new Assertion('contains', 'test');
+    $location = new SourceLocation('/path/to/test.php', 42);
+
+    $tracked = new TrackedAssertion($assertion, $location);
+
+    expect($tracked->assertion)->toBe($assertion)
+        ->and($tracked->sourceLocation)->toBe($location);
+});
+
+test('constructor accepts null sourceLocation', function () {
+    $assertion = new Assertion('contains', 'test');
+
+    $tracked = new TrackedAssertion($assertion);
+
+    expect($tracked->assertion)->toBe($assertion)
+        ->and($tracked->sourceLocation)->toBeNull();
+});
+
+test('matches returns true for same type and value', function () {
+    $assertion1 = new Assertion('contains', 'test');
+    $assertion2 = new Assertion('contains', 'test');
+
+    $tracked = new TrackedAssertion($assertion1);
+
+    expect($tracked->matches($assertion2))->toBeTrue();
+});
+
+test('matches returns false for different type', function () {
+    $assertion1 = new Assertion('contains', 'test');
+    $assertion2 = new Assertion('equals', 'test');
+
+    $tracked = new TrackedAssertion($assertion1);
+
+    expect($tracked->matches($assertion2))->toBeFalse();
+});
+
+test('matches returns false for different value', function () {
+    $assertion1 = new Assertion('contains', 'test');
+    $assertion2 = new Assertion('contains', 'different');
+
+    $tracked = new TrackedAssertion($assertion1);
+
+    expect($tracked->matches($assertion2))->toBeFalse();
+});
+
+test('matches handles negated types correctly', function () {
+    $assertion1 = new Assertion('not-contains', 'test');
+    $assertion2 = new Assertion('not-contains', 'test');
+
+    $tracked = new TrackedAssertion($assertion1);
+
+    expect($tracked->matches($assertion2))->toBeTrue();
+});

--- a/tests/NotModifierTest.php
+++ b/tests/NotModifierTest.php
@@ -16,9 +16,9 @@ test('not modifier negates the next assertion type and then resets', function ()
         ->toContain('allowed');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(2)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains')
-        ->and($testCase->build()->assertions[1]->type)->toBe('icontains');
+    expect($testCase->build()->assertions())->toHaveCount(2)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains')
+        ->and($testCase->build()->assertions()[1]->type)->toBe('icontains');
 });
 
 test('not modifier can be toggled twice to cancel negation', function () {
@@ -30,8 +30,8 @@ test('not modifier can be toggled twice to cancel negation', function () {
     $testCase->not->not->toContain('value');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('icontains');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('icontains');
 });
 
 test('not modifier works with strict mode toContain', function () {
@@ -43,8 +43,8 @@ test('not modifier works with strict mode toContain', function () {
     $testCase->not->toContain('value', strict: true);
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-contains');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-contains');
 });
 
 test('not modifier works with toContainAll', function () {
@@ -56,8 +56,8 @@ test('not modifier works with toContainAll', function () {
     $testCase->not->toContainAll(['value1', 'value2']);
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains-all');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains-all');
 });
 
 test('not modifier works with toContainAny', function () {
@@ -69,8 +69,8 @@ test('not modifier works with toContainAny', function () {
     $testCase->not->toContainAny(['value1', 'value2']);
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains-any');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains-any');
 });
 
 test('not modifier works with toContainJson', function () {
@@ -82,8 +82,8 @@ test('not modifier works with toContainJson', function () {
     $testCase->not->toContainJson();
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-contains-json');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-contains-json');
 });
 
 test('not modifier works with toContainHtml', function () {
@@ -95,8 +95,8 @@ test('not modifier works with toContainHtml', function () {
     $testCase->not->toContainHtml();
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-contains-html');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-contains-html');
 });
 
 test('not modifier works with toContainSql', function () {
@@ -108,8 +108,8 @@ test('not modifier works with toContainSql', function () {
     $testCase->not->toContainSql();
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-contains-sql');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-contains-sql');
 });
 
 test('not modifier works with toContainXml', function () {
@@ -121,8 +121,8 @@ test('not modifier works with toContainXml', function () {
     $testCase->not->toContainXml();
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-contains-xml');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-contains-xml');
 });
 
 test('not modifier works with toBeJudged', function () {
@@ -134,8 +134,8 @@ test('not modifier works with toBeJudged', function () {
     $testCase->not->toBeJudged('rubric text');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-llm-rubric');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-llm-rubric');
 });
 
 test('not modifier preserves value', function () {
@@ -147,9 +147,9 @@ test('not modifier preserves value', function () {
     $testCase->not->toContain('value');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains')
-        ->and($testCase->build()->assertions[0]->value)->toBe('value');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains')
+        ->and($testCase->build()->assertions()[0]->value)->toBe('value');
 });
 
 test('not modifier can be used multiple times independently', function () {
@@ -165,11 +165,11 @@ test('not modifier can be used multiple times independently', function () {
         ->toContain('allowed2');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(4)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains')
-        ->and($testCase->build()->assertions[1]->type)->toBe('icontains')
-        ->and($testCase->build()->assertions[2]->type)->toBe('not-icontains')
-        ->and($testCase->build()->assertions[3]->type)->toBe('icontains');
+    expect($testCase->build()->assertions())->toHaveCount(4)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains')
+        ->and($testCase->build()->assertions()[1]->type)->toBe('icontains')
+        ->and($testCase->build()->assertions()[2]->type)->toBe('not-icontains')
+        ->and($testCase->build()->assertions()[3]->type)->toBe('icontains');
 });
 
 test('not modifier works with three consecutive not calls', function () {
@@ -181,8 +181,8 @@ test('not modifier works with three consecutive not calls', function () {
     $testCase->not->not->not->toContain('value');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains');
 });
 
 test('not modifier works correctly in ConfigBuilder output', function () {
@@ -210,9 +210,9 @@ test('not modifier with toContainAll preserves array value', function () {
     $testCase->not->toContainAll($values);
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains-all')
-        ->and($testCase->build()->assertions[0]->value)->toBe($values);
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains-all')
+        ->and($testCase->build()->assertions()[0]->value)->toBe($values);
 });
 
 test('not modifier with strict toContainAll uses correct type', function () {
@@ -224,8 +224,8 @@ test('not modifier with strict toContainAll uses correct type', function () {
     $testCase->not->toContainAll(['value1', 'value2'], strict: true);
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-contains-all');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-contains-all');
 });
 
 test('not modifier with strict toContainAny uses correct type', function () {
@@ -237,8 +237,8 @@ test('not modifier with strict toContainAny uses correct type', function () {
     $testCase->not->toContainAny(['value1', 'value2'], strict: true);
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-contains-any');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-contains-any');
 });
 
 // Tests for not() method call syntax
@@ -254,9 +254,9 @@ test('not() method negates the next assertion type', function () {
         ->toContain('allowed');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(2)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains')
-        ->and($testCase->build()->assertions[1]->type)->toBe('icontains');
+    expect($testCase->build()->assertions())->toHaveCount(2)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains')
+        ->and($testCase->build()->assertions()[1]->type)->toBe('icontains');
 });
 
 test('not() method can be toggled twice to cancel negation', function () {
@@ -268,8 +268,8 @@ test('not() method can be toggled twice to cancel negation', function () {
     $testCase->not()->not()->toContain('value');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('icontains');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('icontains');
 });
 
 test('not() method works with all assertion types', function () {
@@ -286,12 +286,12 @@ test('not() method works with all assertion types', function () {
         ->not()->toBeJudged('rubric');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(5)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains')
-        ->and($testCase->build()->assertions[1]->type)->toBe('not-icontains-all')
-        ->and($testCase->build()->assertions[2]->type)->toBe('not-icontains-any')
-        ->and($testCase->build()->assertions[3]->type)->toBe('not-contains-json')
-        ->and($testCase->build()->assertions[4]->type)->toBe('not-llm-rubric');
+    expect($testCase->build()->assertions())->toHaveCount(5)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains')
+        ->and($testCase->build()->assertions()[1]->type)->toBe('not-icontains-all')
+        ->and($testCase->build()->assertions()[2]->type)->toBe('not-icontains-any')
+        ->and($testCase->build()->assertions()[3]->type)->toBe('not-contains-json')
+        ->and($testCase->build()->assertions()[4]->type)->toBe('not-llm-rubric');
 });
 
 test('not() method and not property can be mixed', function () {
@@ -306,10 +306,10 @@ test('not() method and not property can be mixed', function () {
         ->toContain('regular');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(3)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains')
-        ->and($testCase->build()->assertions[1]->type)->toBe('not-icontains')
-        ->and($testCase->build()->assertions[2]->type)->toBe('icontains');
+    expect($testCase->build()->assertions())->toHaveCount(3)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains')
+        ->and($testCase->build()->assertions()[1]->type)->toBe('not-icontains')
+        ->and($testCase->build()->assertions()[2]->type)->toBe('icontains');
 });
 
 test('not() method preserves value', function () {
@@ -321,7 +321,7 @@ test('not() method preserves value', function () {
     $testCase->not()->toContain('value');
 
     // Assert
-    expect($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0]->type)->toBe('not-icontains')
-        ->and($testCase->build()->assertions[0]->value)->toBe('value');
+    expect($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0]->type)->toBe('not-icontains')
+        ->and($testCase->build()->assertions()[0]->value)->toBe('value');
 });

--- a/tests/Promptfoo/ConfigBuilderTest.php
+++ b/tests/Promptfoo/ConfigBuilderTest.php
@@ -47,7 +47,9 @@ test('toArray returns array with all fields when populated', function () {
         ->and($result['tests'][0]['assert'][0]['type'])->toBe('contains')
         ->and($result['tests'][0]['assert'][0]['value'])->toBe('expected value')
         ->and($result['tests'][0]['assert'][0]['threshold'])->toBe(0.8)
-        ->and($result['tests'][0]['assert'][0]['config'])->toBe(['option1' => 'value1']);
+        ->and($result['tests'][0]['assert'][0]['config'])->toHaveKey('option1')
+        ->and($result['tests'][0]['assert'][0]['config']['option1'])->toBe('value1')
+        ->and($result['tests'][0]['assert'][0]['config'])->toHaveKey(Assertion::INTERNAL_CONFIG_KEY);
 });
 
 test('toArray filters out null description', function () {
@@ -79,7 +81,7 @@ test('toArray filters out null threshold in assertions', function () {
     expect($result['tests'][0]['assert'][0])->not->toHaveKey('threshold');
 });
 
-test('toArray filters out null config in assertions', function () {
+test('toArray always includes internal config for assertion tracking', function () {
     $evaluation = new Evaluation(['prompt1']);
     $testCase = $evaluation->expect(['key' => 'value']);
     $testCase->assert(new Assertion('contains', 'test', null, null, null, null, null, null, null));
@@ -87,7 +89,10 @@ test('toArray filters out null config in assertions', function () {
     $builder = ConfigBuilder::fromEvaluation($evaluation);
     $result = $builder->toArray();
 
-    expect($result['tests'][0]['assert'][0])->not->toHaveKey('config');
+    // Assertions now always have internal config with assertion_id for source location tracking
+    expect($result['tests'][0]['assert'][0])->toHaveKey('config')
+        ->and($result['tests'][0]['assert'][0]['config'])->toHaveKey(Assertion::INTERNAL_CONFIG_KEY)
+        ->and($result['tests'][0]['assert'][0]['config'][Assertion::INTERNAL_CONFIG_KEY])->toHaveKey(Assertion::INTERNAL_ASSERTION_ID_KEY);
 });
 
 test('toArray handles multiple test cases', function () {
@@ -217,10 +222,12 @@ test('toArray handles assertion with only type and value', function () {
         ->and($result['tests'][0]['assert'][0]['type'])->toBe('contains')
         ->and($result['tests'][0]['assert'][0]['value'])->toBe('test value')
         ->and($result['tests'][0]['assert'][0])->not->toHaveKey('threshold')
-        ->and($result['tests'][0]['assert'][0])->not->toHaveKey('config');
+        // Config now always exists with internal assertion_id for source location tracking
+        ->and($result['tests'][0]['assert'][0])->toHaveKey('config')
+        ->and($result['tests'][0]['assert'][0]['config'])->toHaveKey(Assertion::INTERNAL_CONFIG_KEY);
 });
 
-test('toArray handles assertion with threshold but no config', function () {
+test('toArray handles assertion with threshold but no user config', function () {
     $evaluation = new Evaluation(['prompt1']);
     $testCase = $evaluation->expect(['key' => 'value']);
     $testCase->assert(new Assertion('contains', 'test', 0.75));
@@ -230,10 +237,12 @@ test('toArray handles assertion with threshold but no config', function () {
 
     expect($result['tests'][0]['assert'][0])->toHaveKey('threshold')
         ->and($result['tests'][0]['assert'][0]['threshold'])->toBe(0.75)
-        ->and($result['tests'][0]['assert'][0])->not->toHaveKey('config');
+        // Config now always exists with internal assertion_id for source location tracking
+        ->and($result['tests'][0]['assert'][0])->toHaveKey('config')
+        ->and($result['tests'][0]['assert'][0]['config'])->toHaveKey(Assertion::INTERNAL_CONFIG_KEY);
 });
 
-test('toArray handles assertion with config but no threshold', function () {
+test('toArray handles assertion with user config but no threshold', function () {
     $evaluation = new Evaluation(['prompt1']);
     $testCase = $evaluation->expect(['key' => 'value']);
     $testCase->assert(new Assertion('contains', 'test', null, config: ['key' => 'value']));
@@ -243,7 +252,10 @@ test('toArray handles assertion with config but no threshold', function () {
 
     expect($result['tests'][0]['assert'][0])->not->toHaveKey('threshold')
         ->and($result['tests'][0]['assert'][0])->toHaveKey('config')
-        ->and($result['tests'][0]['assert'][0]['config'])->toBe(['key' => 'value']);
+        // User config is preserved alongside internal assertion_id
+        ->and($result['tests'][0]['assert'][0]['config'])->toHaveKey('key')
+        ->and($result['tests'][0]['assert'][0]['config']['key'])->toBe('value')
+        ->and($result['tests'][0]['assert'][0]['config'])->toHaveKey(Assertion::INTERNAL_CONFIG_KEY);
 });
 
 test('toArray handles FinishReason enum correctly', function () {
@@ -368,4 +380,47 @@ test('toArray handles defaultTest with both vars and assert', function () {
         ->and($result['defaultTest'])->toHaveKey('assert')
         ->and($result['defaultTest']['vars'])->toBe(['default' => 'value', 'another' => 'test'])
         ->and($result['defaultTest']['assert'])->toHaveCount(2);
+});
+
+test('toArray includes internal assertion IDs in config', function () {
+    $evaluation = new Evaluation(['prompt1']);
+    $testCase = $evaluation->expect(['key' => 'value']);
+    $testCase->toContain('test1');
+    $testCase->toContain('test2');
+
+    $builder = ConfigBuilder::fromEvaluation($evaluation);
+    $result = $builder->toArray();
+
+    // Both assertions should have internal config with assertion IDs
+    expect($result['tests'][0]['assert'])->toHaveCount(2);
+
+    foreach ($result['tests'][0]['assert'] as $assertion) {
+        expect($assertion)->toHaveKey('config')
+            ->and($assertion['config'])->toHaveKey(Assertion::INTERNAL_CONFIG_KEY)
+            ->and($assertion['config'][Assertion::INTERNAL_CONFIG_KEY])->toHaveKey(Assertion::INTERNAL_ASSERTION_ID_KEY)
+            ->and($assertion['config'][Assertion::INTERNAL_CONFIG_KEY][Assertion::INTERNAL_ASSERTION_ID_KEY])->toBeString()
+            ->and($assertion['config'][Assertion::INTERNAL_CONFIG_KEY][Assertion::INTERNAL_ASSERTION_ID_KEY])->toHaveLength(40); // SHA1 hash length
+    }
+
+    // The two assertion IDs should be different (different indices)
+    $id1 = $result['tests'][0]['assert'][0]['config'][Assertion::INTERNAL_CONFIG_KEY][Assertion::INTERNAL_ASSERTION_ID_KEY];
+    $id2 = $result['tests'][0]['assert'][1]['config'][Assertion::INTERNAL_CONFIG_KEY][Assertion::INTERNAL_ASSERTION_ID_KEY];
+    expect($id1)->not->toBe($id2);
+});
+
+test('toArray preserves user config alongside internal assertion IDs', function () {
+    $evaluation = new Evaluation(['prompt1']);
+    $testCase = $evaluation->expect(['key' => 'value']);
+    $testCase->assert(new Assertion('contains', 'test', config: ['userKey' => 'userValue']));
+
+    $builder = ConfigBuilder::fromEvaluation($evaluation);
+    $result = $builder->toArray();
+
+    $assertionConfig = $result['tests'][0]['assert'][0]['config'];
+
+    // Should have both user config and internal config
+    expect($assertionConfig)->toHaveKey('userKey')
+        ->and($assertionConfig['userKey'])->toBe('userValue')
+        ->and($assertionConfig)->toHaveKey(Assertion::INTERNAL_CONFIG_KEY)
+        ->and($assertionConfig[Assertion::INTERNAL_CONFIG_KEY])->toHaveKey(Assertion::INTERNAL_ASSERTION_ID_KEY);
 });

--- a/tests/TestCaseTest.php
+++ b/tests/TestCaseTest.php
@@ -39,9 +39,12 @@ test('it can add an assertion', function () {
 
     $result = $testCase->assert($assertion);
 
+    // The stored assertion is a new instance with internal ID attached
     expect($result)->toBe($testCase)
         ->and($testCase->build()->assertions())->toHaveCount(1)
-        ->and($testCase->build()->assertions()[0])->toBe($assertion);
+        ->and($testCase->build()->assertions()[0]->type)->toBe($assertion->type)
+        ->and($testCase->build()->assertions()[0]->value)->toBe($assertion->value)
+        ->and($testCase->build()->assertions()[0]->getInternalId())->not->toBeNull();
 });
 
 test('it can add multiple assertions', function () {
@@ -54,9 +57,12 @@ test('it can add multiple assertions', function () {
     $testCase->assert($assertion1);
     $testCase->assert($assertion2);
 
+    // Each stored assertion is a new instance with internal ID attached
     expect($testCase->build()->assertions())->toHaveCount(2)
-        ->and($testCase->build()->assertions()[0])->toBe($assertion1)
-        ->and($testCase->build()->assertions()[1])->toBe($assertion2);
+        ->and($testCase->build()->assertions()[0]->type)->toBe($assertion1->type)
+        ->and($testCase->build()->assertions()[0]->value)->toBe($assertion1->value)
+        ->and($testCase->build()->assertions()[1]->type)->toBe($assertion2->type)
+        ->and($testCase->build()->assertions()[1]->value)->toBe($assertion2->value);
 });
 
 test('and method returns a new TestCase from evaluation', function () {

--- a/tests/TestCaseTest.php
+++ b/tests/TestCaseTest.php
@@ -28,7 +28,7 @@ test('it returns an empty array of assertions initially', function () {
     $variables = ['key1' => 'value1', 'key2' => 'value2'];
     $testCase = new TestCase($variables, $evaluation);
 
-    expect($testCase->build()->assertions)->toBe([]);
+    expect($testCase->build()->assertions())->toBe([]);
 });
 
 test('it can add an assertion', function () {
@@ -40,8 +40,8 @@ test('it can add an assertion', function () {
     $result = $testCase->assert($assertion);
 
     expect($result)->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1)
-        ->and($testCase->build()->assertions[0])->toBe($assertion);
+        ->and($testCase->build()->assertions())->toHaveCount(1)
+        ->and($testCase->build()->assertions()[0])->toBe($assertion);
 });
 
 test('it can add multiple assertions', function () {
@@ -54,9 +54,9 @@ test('it can add multiple assertions', function () {
     $testCase->assert($assertion1);
     $testCase->assert($assertion2);
 
-    expect($testCase->build()->assertions)->toHaveCount(2)
-        ->and($testCase->build()->assertions[0])->toBe($assertion1)
-        ->and($testCase->build()->assertions[1])->toBe($assertion2);
+    expect($testCase->build()->assertions())->toHaveCount(2)
+        ->and($testCase->build()->assertions()[0])->toBe($assertion1)
+        ->and($testCase->build()->assertions()[1])->toBe($assertion2);
 });
 
 test('and method returns a new TestCase from evaluation', function () {
@@ -85,8 +85,8 @@ test('and method can be chained with assertions', function () {
 
     expect($result)->toBeInstanceOf(TestCase::class)
         ->and($result)->not->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1)
-        ->and($result->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1)
+        ->and($result->build()->assertions())->toHaveCount(1);
 });
 
 test('expect method returns a new TestCase from evaluation', function () {
@@ -115,8 +115,8 @@ test('expect method can be chained with assertions', function () {
 
     expect($result)->toBeInstanceOf(TestCase::class)
         ->and($result)->not->toBe($testCase)
-        ->and($testCase->build()->assertions)->toHaveCount(1)
-        ->and($result->build()->assertions)->toHaveCount(1);
+        ->and($testCase->build()->assertions())->toHaveCount(1)
+        ->and($result->build()->assertions())->toHaveCount(1);
 });
 
 test('expect method can be called with empty variables array', function () {
@@ -178,8 +178,8 @@ test('expect method callback can be used to add assertions', function () {
             ->toContain('value');
     });
 
-    expect($result->build()->assertions)->toHaveCount(2)
-        ->and($testCase->build()->assertions)->toHaveCount(0);
+    expect($result->build()->assertions())->toHaveCount(2)
+        ->and($testCase->build()->assertions())->toHaveCount(0);
 });
 
 test('expect method works without callback', function () {
@@ -236,8 +236,8 @@ test('and method callback can be used to add assertions', function () {
             ->toContain('value');
     });
 
-    expect($result->build()->assertions)->toHaveCount(2)
-        ->and($testCase->build()->assertions)->toHaveCount(0);
+    expect($result->build()->assertions())->toHaveCount(2)
+        ->and($testCase->build()->assertions())->toHaveCount(0);
 });
 
 test('and method works without callback', function () {
@@ -279,11 +279,11 @@ test('magic toXxx method applies named assertion group without arguments', funct
     $built = $testCase->build();
 
     expect($result)->toBe($testCase)
-        ->and($built->assertions)->toHaveCount(2)
-        ->and($built->assertions[0]->type)->toBe('icontains')
-        ->and($built->assertions[0]->value)->toBe('hello')
-        ->and($built->assertions[1]->type)->toBe('llm-rubric')
-        ->and($built->assertions[1]->value)->toBe('friendly');
+        ->and($built->assertions())->toHaveCount(2)
+        ->and($built->assertions()[0]->type)->toBe('icontains')
+        ->and($built->assertions()[0]->value)->toBe('hello')
+        ->and($built->assertions()[1]->type)->toBe('llm-rubric')
+        ->and($built->assertions()[1]->value)->toBe('friendly');
 });
 
 test('magic toXxx method applies named assertion group with arguments', function () {
@@ -302,9 +302,9 @@ test('magic toXxx method applies named assertion group with arguments', function
     $built = $testCase->build();
 
     expect($result)->toBe($testCase)
-        ->and($built->assertions)->toHaveCount(2)
-        ->and($built->assertions[0]->value)->toBe('gentle')
-        ->and($built->assertions[1]->value)->toBe('be gentle');
+        ->and($built->assertions())->toHaveCount(2)
+        ->and($built->assertions()[0]->value)->toBe('gentle')
+        ->and($built->assertions()[1]->value)->toBe('be gentle');
 });
 
 test('magic toXxx method expects at most one array argument', function () {


### PR DESCRIPTION
Adds better failed assertion tracker, shows the failed test file and which line failed.

- Add SourceLocation value object to capture test file/line from backtrace
- Add TrackedAssertion wrapper to pair assertions with their source locations
- Add PromptAssertionFailedException for better error reporting with Collision
- Remove AssertionSourceRegistry in favor of direct TrackedAssertion lookup
- Remove invokable class FQN support from to()/group() - use named groups or instances
- Update README to document simplified assertion group API
- Keep Assertion DTO pure (no source tracking pollution)